### PR TITLE
fix: move PaperProvider above ThemedView to fix production crash

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -86,15 +86,15 @@ function RootContent() {
     }
   }, [isDarkMode, theme.colors.background]);
 
-  return (<>
-    <StatusBar
-      barStyle={isDarkMode ? "light-content" : "dark-content"}
-      backgroundColor={theme.colors.background}
-    />
-    <SafeAreaView style={{ flex: 1, backgroundColor: theme.colors.background }} edges={["left", "right", "bottom"]}>
-      <ThemedView type="card" style={{ width: "100%", flex: 1, alignContent: "center", backgroundColor: theme.colors.background }}>
-        <View style={pathname == "/" ? { flex: 1 } : { maxWidth: 600, width: "100%", flex: 1, alignSelf: "center" }}>
-          <PaperProvider theme={theme}>
+  return (
+    <PaperProvider theme={theme}>
+      <StatusBar
+        barStyle={isDarkMode ? "light-content" : "dark-content"}
+        backgroundColor={theme.colors.background}
+      />
+      <SafeAreaView style={{ flex: 1, backgroundColor: theme.colors.background }} edges={["left", "right", "bottom"]}>
+        <ThemedView type="card" style={{ width: "100%", flex: 1, alignContent: "center", backgroundColor: theme.colors.background }}>
+          <View style={pathname == "/" ? { flex: 1 } : { maxWidth: 600, width: "100%", flex: 1, alignSelf: "center" }}>
             <InfoLayer />
             <Stack
               screenOptions={{ header: () => <MyAppbar /> }}
@@ -141,11 +141,11 @@ function RootContent() {
               !pathname.includes("login") &&
               !pathname.includes("password") &&
               !pathname.includes("csatlakozom") && <BottomNavigation />}
-          </PaperProvider>
-        </View>
-      </ThemedView>
-    </SafeAreaView>
-  </>);
+          </View>
+        </ThemedView>
+      </SafeAreaView>
+    </PaperProvider>
+  );
 }
 
 export default function RootLayout() {


### PR DESCRIPTION
ThemedView calls useTheme() from react-native-paper, but PaperProvider
was nested below it in the tree. In development this silently fell back
to a default theme; the react-native-paper/babel production plugin made
the missing context fatal, causing the app to crash on startup.

https://claude.ai/code/session_01PMVMG1H9xJw3qj3GFDAw5j