### PR TITLE
fix: replace navigation.setOptions header with Stack.Screen in protec…

### DIFF
--- a/app/(protected)/biznisz/[id].tsx
+++ b/app/(protected)/biznisz/[id].tsx
@@ -28,9 +28,9 @@ import { PostgrestError } from "@supabase/supabase-js";
 import {
   Link,
   router,
+  Stack,
   useFocusEffect,
   useGlobalSearchParams,
-  useNavigation,
 } from "expo-router";
 import { useCallback, useEffect, useState } from "react";
 import { ScrollView, useWindowDimensions, View } from "react-native";
@@ -54,7 +54,6 @@ import { clearOptions, setOptions } from "@/redux/reducers/infoReducer";
 
 export default function Index() {
   const { id: paramId } = useGlobalSearchParams();
-  const navigation = useNavigation().getParent();
   const { width } = useWindowDimensions();
   const dispatch = useDispatch();
   const { uid: myUid }: UserState = useSelector(
@@ -132,8 +131,6 @@ export default function Index() {
                 authorName: data?.profiles?.full_name || "???",
                 avatarUrl: data?.profiles?.avatar_url,
               });
-              navigation.setOptions({ header: () => <MyAppbar center={<Text variant="titleLarge">{data?.title?.split(" $ ")[0]}</Text>} style={{ elevation: 0, shadowOpacity: 0, borderBottomWidth: 0 }} /> });
-
               if (data.images) setImages(getImagesUrlFromSupabase(data.images));
               if (data.defaultContact) {
                 if (data.contacts) {
@@ -180,6 +177,8 @@ export default function Index() {
     }
   };
   return (
+    <>
+    <Stack.Screen options={{ header: () => <MyAppbar center={data?.title ? <Text variant="titleLarge">{data.title.split(" $ ")[0]}</Text> : undefined} style={{ elevation: 0, shadowOpacity: 0, borderBottomWidth: 0 }} /> }} />
     <ThemedView style={{ flex: 1 }}>
       <ScrollView >
         {!data && !error && <ActivityIndicator />}
@@ -426,5 +425,6 @@ export default function Index() {
         )}
       </ScrollView>
     </ThemedView>
+    </>
   );
 }

--- a/app/(protected)/home.tsx
+++ b/app/(protected)/home.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/redux/reducers/usersReducer";
 import { viewFunction } from "@/redux/reducers/tutorialReducer";
 import { RootState } from "@/redux/store";
-import { router, useFocusEffect, useNavigation } from "expo-router";
+import { router, Stack, useFocusEffect } from "expo-router";
 import { useCallback, useEffect, useState } from "react";
 import { View } from "react-native";
 import style from "@/components/styles";
@@ -28,7 +28,6 @@ import { useProfileSearch } from "@/hooks/useProfileSearch";
 
 export default function Index() {
   const { uid } = useSelector((state: RootState) => state.user);
-  const navigation = useNavigation().getParent();
   const { userSearchParams } = useSelector(
     (state: RootState) => state.users,
   );
@@ -60,12 +59,13 @@ export default function Index() {
         fetchNewest();
       }
       if (uid) dispatch(viewFunction({ key: "homePage", uid }));
-      navigation.setOptions({ header: () => <MyAppbar center={<BuzinessSearchInput onSearch={handleSearch} />} style={{ elevation: 0, shadowOpacity: 0, borderBottomWidth: 0 }} /> });
-    }, [data.length, newestUsers.length, uid, dispatch, navigation, fetch, fetchNewest, handleSearch]),
+    }, [data.length, newestUsers.length, uid, dispatch, fetch, fetchNewest]),
   );
 
   if (uid)
     return (
+      <>
+      <Stack.Screen options={{ header: () => <MyAppbar center={<BuzinessSearchInput onSearch={handleSearch} />} style={{ elevation: 0, shadowOpacity: 0, borderBottomWidth: 0 }} /> }} />
       <ThemedView style={{ flex: 1, zIndex: 100 }} type="default">
         <ThemedView style={{ width: "100%", alignItems: "center", zIndex: 100 }} type="card">
           <View style={{ flexDirection: "row", alignItems: "center", gap: 8, paddingHorizontal: 16, paddingTop: 8, paddingBottom: 4 }}>
@@ -126,5 +126,6 @@ export default function Index() {
           </Modal>
         </Portal>
       </ThemedView>
+      </>
     );
 }

--- a/components/buziness/BuzinessEditScreen.tsx
+++ b/components/buziness/BuzinessEditScreen.tsx
@@ -12,7 +12,7 @@ import {
 import { RootState } from "@/redux/store";
 import { ImageDataType, UserState } from "@/redux/store.type";
 import { supabase } from "@/lib/supabase/supabase";
-import { router, useFocusEffect, useNavigation } from "expo-router";
+import { router, Stack, useFocusEffect } from "expo-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ScrollView, View } from "react-native";
 import {
@@ -82,8 +82,6 @@ export default function BuzinessEditScreen({
   const [locationTutorialVisible, setLocationTutorialVisible] = useState(false);
 
   const title = newBuziness.title + " $ " + categories;
-  const navigation = useNavigation().getParent();
-
   const canSubmit = !!(
     newBuziness.title &&
     categories &&
@@ -184,7 +182,6 @@ export default function BuzinessEditScreen({
   useFocusEffect(
     useCallback(() => {
       if (editId && uid) {
-        navigation.setOptions({ title: "Biznisz szerkesztése" });
         supabase
           .from("buziness")
           .select("*")
@@ -246,6 +243,8 @@ export default function BuzinessEditScreen({
   );
 
   return (
+    <>
+    {editId && <Stack.Screen options={{ title: "Biznisz szerkesztése" }} />}
     <ThemedView style={{ flex: 1 }}>
       <ScrollView style={{ flex: 1 }} contentContainerStyle={{}}>
         {tutorialVisible && (
@@ -513,5 +512,6 @@ export default function BuzinessEditScreen({
         </Modal>
       </Portal>
     </ThemedView>
+    </>
   );
 }

--- a/components/user/UserPage.tsx
+++ b/components/user/UserPage.tsx
@@ -21,9 +21,9 @@ import { supabase } from "@/lib/supabase/supabase";
 import {
   Link,
   router,
+  Stack,
   useFocusEffect,
   useGlobalSearchParams,
-  useNavigation,
 } from "expo-router";
 import React, { useCallback, useState } from "react";
 import { useWindowDimensions, View } from "react-native";
@@ -71,7 +71,6 @@ export default function UserPage() {
   const theme = useTheme();
 
   const dispatch = useDispatch();
-  const navigation = useNavigation();
   const { width } = useWindowDimensions();
   const myProfile = myUid === uid;
   const [data, setData] = useState<UserInfo | null>(null);
@@ -82,8 +81,6 @@ export default function UserPage() {
 
   useFocusEffect(
     useCallback(() => {
-      navigation.setOptions({ header: () => <MyAppbar style={{ elevation: 0, shadowOpacity: 0, borderBottomWidth: 0 }} /> });
-
       const load = () => {
         if (!uid) return;
 
@@ -136,6 +133,7 @@ export default function UserPage() {
 
   return (
     <>
+      <Stack.Screen options={{ header: () => <MyAppbar style={{ elevation: 0, shadowOpacity: 0, borderBottomWidth: 0 }} /> }} />
       <ThemedView style={{ flex: 1 }}>
         {!!data && !!uid && (
           <>


### PR DESCRIPTION
…ted screens

Components inside (protected)/_layout.tsx's Slot navigator called navigation[.getParent()].setOptions({ header: () => <Component> }) to customise the app bar. In production, this causes the header callback to render outside the PaperProvider context, throwing the "forgot to wrap with Provider" error after login.

Replace all four call-sites with Expo Router's declarative <Stack.Screen options={{ header: ... }} /> which renders the header within the same Stack subtree that is inside PaperProvider.

https://claude.ai/code/session_01PMVMG1H9xJw3qj3GFDAw5j