### PR TITLE
Redesign add-biznisz flow and profile sections

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -174,7 +174,9 @@ function RootContent() {
             {pathname !== "/" && !pathname.includes("projekt") &&
               !pathname.includes("login") &&
               !pathname.includes("password") &&
-              !pathname.includes("csatlakozom") && <BottomNavigation />}
+              !pathname.includes("csatlakozom") &&
+              pathname !== "/biznisz/new" &&
+              !pathname.startsWith("/biznisz/edit") && <BottomNavigation />}
           </View>
         </ThemedView>
       </SafeAreaView>

--- a/components/MyAppBar.tsx
+++ b/components/MyAppBar.tsx
@@ -49,7 +49,7 @@ export const MyAppbar = ({ center, title, style }: { center?: ReactNode, title?:
         </View>
         {center ? <View style={{ flex: 1 }}>{center}</View>
           : title ?
-            <Appbar.Content titleStyle={{ fontFamily: "Piazzolla-ExtraBold", fontSize: 26 }} title={title} style={{ flex: 1 }} />
+            <Appbar.Content titleStyle={{ fontFamily: "Piazzolla-ExtraBold", fontSize: 20 }} title={title} style={{ flex: 1 }} />
             : <BuzinessSearchInput 
             onSearch={() => {
               dispatch(storeBuzinesses([]));

--- a/components/TagInput.tsx
+++ b/components/TagInput.tsx
@@ -1,116 +1,186 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   NativeSyntheticEvent,
   StyleProp,
+  TextInput as RNTextInput,
   TextInputKeyPressEventData,
-  TextInputSubmitEditingEventData,
+  View,
   ViewStyle,
 } from "react-native";
-import { Card, Chip, TextInput } from "react-native-paper";
+import { Chip, IconButton, TextInput } from "react-native-paper";
 import { Spacing } from "@/constants/spacing";
+import { BorderRadius } from "@/constants/borderRadius";
+import { useAppTheme } from "@/assets/theme";
 
-interface TagInputType {
-  onChange: React.SetStateAction<any>;
-  value?: string;
-  defaultValue?: string;
-  style?: StyleProp<ViewStyle>;
+interface TagInputProps {
+  value: string[];
+  onChange: (next: string[]) => void;
   placeholder?: string;
+  style?: StyleProp<ViewStyle>;
 }
 
 const TagInput = ({
-  onChange,
-  defaultValue,
-  style,
-  placeholder,
   value,
-}: TagInputType) => {
-  const inputRef = useRef(null);
-  const list = (value || "")
-    .split(" $ ")
-    .slice(0, -1)
-    .filter((e) => e.length);
-  const text = (value || "").split(" $ ").slice(-1)[0];
+  onChange,
+  placeholder = "Új kulcsszó…",
+  style,
+}: TagInputProps) => {
+  const theme = useAppTheme();
+  const inputRef = useRef<RNTextInput>(null);
+  const [adding, setAdding] = useState(false);
+  const [draft, setDraft] = useState("");
 
-  const edit = (e: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
-    if (e.nativeEvent.key === "Backspace" && text === "") {
-      e.preventDefault();
-      onChange(toString([...list]));
+  useEffect(() => {
+    if (adding) {
+      const t = setTimeout(() => inputRef.current?.focus(), 0);
+      return () => clearTimeout(t);
+    }
+  }, [adding]);
+
+  const commitTag = (raw: string) => {
+    const trimmed = raw.trim();
+    if (!trimmed) return false;
+    if (value.includes(trimmed)) return false;
+    onChange([...value, trimmed]);
+    return true;
+  };
+
+  const handleChangeText = (text: string) => {
+    if (text.includes(",")) {
+      const parts = text.split(",");
+      const toCommit = parts.slice(0, -1);
+      let next = [...value];
+      for (const p of toCommit) {
+        const t = p.trim();
+        if (t && !next.includes(t)) next.push(t);
+      }
+      onChange(next);
+      setDraft(parts[parts.length - 1]);
+    } else {
+      setDraft(text);
     }
   };
-  const onSubmit = (
-    e: NativeSyntheticEvent<TextInputSubmitEditingEventData>,
+
+  const handleSubmit = () => {
+    if (commitTag(draft)) {
+      setDraft("");
+    } else if (!draft.trim()) {
+      setAdding(false);
+    }
+  };
+
+  const handleBlur = () => {
+    if (commitTag(draft)) {
+      setDraft("");
+    }
+    if (!draft.trim()) {
+      setAdding(false);
+    }
+  };
+
+  const handleKeyPress = (
+    e: NativeSyntheticEvent<TextInputKeyPressEventData>,
   ) => {
-    onChange(toString([...list, text.trim() + " $ "]));
-    e.preventDefault();
-  };
-  const onBlur = () => {
-    if (text.length) {
-      onChange(toString([...list, text.trim(), " $ "]));
+    if (e.nativeEvent.key === "Backspace" && draft === "" && value.length > 0) {
+      e.preventDefault?.();
+      onChange(value.slice(0, -1));
     }
   };
-  const onChangeText = (e: string) => {
-    if (!e.includes("$")) onChange(toString(list) + " $ " + e);
+
+  const cancelAdding = () => {
+    setDraft("");
+    setAdding(false);
   };
 
-  const toString = (arr: string[]): string => {
-    return arr.reduce((partialSum, a) => partialSum + " $ " + a, "");
+  const removeTag = (index: number) => {
+    onChange(value.filter((_, i) => i !== index));
   };
 
-  const TagList = () => (
-    <>
-      {list.map((e, i) => {
-        if (e.length)
-          return (
-            <Chip
-              key={"tags" + i}
-              mode="flat"
-              style={{ margin: Spacing.xs }}
-              onClose={() => {
-                onChange(toString(list.filter((el, ind) => ind !== i)) + " $ ");
-              }}
-              closeIcon="close"
-            >
-              {e}
-            </Chip>
-          );
-      })}
-    </>
-  );
   return (
-    <Card
-      mode="contained"
-      contentStyle={{
-        flexDirection: "row",
-        flexWrap: "wrap",
-        alignItems: "center",
-      }}
+    <View
       style={[
         {
-          borderRadius: 0,
+          flexDirection: "row",
+          flexWrap: "wrap",
+          alignItems: "center",
+          gap: Spacing.xs,
         },
         style,
       ]}
     >
-      <TagList />
-      <TextInput
-        placeholder={placeholder}
-        contentStyle={{ flexGrow: 1 }}
-        style={{
-          flexGrow: 1,
-          fontSize: 17,
-          padding: Spacing.xs,
-          borderRadius: 0,
-        }}
-        ref={inputRef}
-        returnKeyType="next"
-        blurOnSubmit={false}
-        onSubmitEditing={onSubmit}
-        onChangeText={onChangeText}
-        onKeyPress={edit}
-        onBlur={onBlur}
-        value={text}
-      />
-    </Card>
+      {value.map((tag, i) => (
+        <Chip
+          key={`tag-${i}-${tag}`}
+          mode="flat"
+          onClose={() => removeTag(i)}
+          closeIcon="close"
+        >
+          {tag}
+        </Chip>
+      ))}
+
+      {adding ? (
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            flexGrow: 1,
+            minWidth: 140,
+            borderWidth: 1,
+            borderColor: theme.colors.primary,
+            borderRadius: BorderRadius.pill,
+            paddingLeft: Spacing.md,
+            paddingRight: Spacing.xs,
+            backgroundColor: theme.colors.surface,
+          }}
+        >
+          <TextInput
+            ref={inputRef}
+            mode="flat"
+            dense
+            value={draft}
+            placeholder={placeholder}
+            onChangeText={handleChangeText}
+            onSubmitEditing={handleSubmit}
+            onBlur={handleBlur}
+            onKeyPress={handleKeyPress}
+            returnKeyType="done"
+            blurOnSubmit={false}
+            underlineColor="transparent"
+            activeUnderlineColor="transparent"
+            style={{
+              flexGrow: 1,
+              flexShrink: 1,
+              backgroundColor: "transparent",
+              fontSize: 14,
+              height: 32,
+              paddingHorizontal: 0,
+            }}
+            contentStyle={{ paddingHorizontal: 0 }}
+          />
+          <IconButton
+            icon="close"
+            size={16}
+            onPress={cancelAdding}
+            style={{ margin: 0 }}
+            accessibilityLabel="Mégse"
+          />
+        </View>
+      ) : (
+        <Chip
+          mode="outlined"
+          icon="plus"
+          onPress={() => setAdding(true)}
+          style={{
+            borderStyle: "dashed",
+            borderColor: theme.colors.outline,
+            backgroundColor: "transparent",
+          }}
+        >
+          Új kulcsszó
+        </Chip>
+      )}
+    </View>
   );
 };
 

--- a/components/buziness/BuzinessEditScreen.tsx
+++ b/components/buziness/BuzinessEditScreen.tsx
@@ -4,11 +4,9 @@ import TagInput from "@/components/TagInput";
 import { useMyLocation } from "@/hooks/useMyLocation";
 import locationToCoords from "@/lib/functions/locationToCoords";
 import {
-  clearOptions,
+  addSnack,
   hideLoading,
-  setOptions,
   showLoading,
-  addSnack
 } from "@/redux/reducers/infoReducer";
 import { RootState } from "@/redux/store";
 import { CircleType, ImageDataType, UserState } from "@/redux/store.type";
@@ -17,46 +15,36 @@ import { router, Stack, useFocusEffect } from "expo-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ScrollView, View } from "react-native";
 import {
-  Card,
-  Divider,
-  Headline,
+  Dialog,
+  HelperText,
   Icon,
   IconButton,
-  List,
-  MD3DarkTheme,
   Modal,
   Portal,
   SegmentedButtons,
+  Surface,
   Switch,
   Text,
   TextInput,
-  TouchableRipple,
 } from "react-native-paper";
 import { useDispatch, useSelector } from "react-redux";
 import { Marker } from "../mapView/mapView";
 import FiFeMap from "../mapView/FiFeMap";
 import { ThemedView } from "../ThemedView";
-import {
-  Dropdown,
-  DropdownInputProps,
-  Option,
-} from "react-native-paper-dropdown";
-import typeToIcon from "@/lib/functions/typeToIcon";
-import { ThemedText } from "../ThemedText";
 import BuzinessImageUpload, {
   BuzinessImageUploadHandle,
 } from "./BuzinessImageUpload";
 import getImagesUrlFromSupabase from "@/lib/functions/getImagesUrlFromSupabase";
-import { Image } from "expo-image";
 import NewMarkerIcon from "@/assets/images/newMarkerIcon";
 import BuzinessItem from "./BuzinessItem";
 import { Button } from "../Button";
 import ContactEditScreen from "./ContactEditScreen";
 import { PostgrestSingleResponse } from "@supabase/supabase-js";
 import { Tables } from "@/database.types";
-import { theme } from "@/assets/theme";
+import { useAppTheme } from "@/assets/theme";
 import { Spacing } from "@/constants/spacing";
 import { BorderRadius } from "@/constants/borderRadius";
+import SectionLabel from "./SectionLabel";
 
 interface NewBuzinessInterface {
   title: string;
@@ -67,21 +55,22 @@ interface BuzinessEditScreenProps {
 }
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
-// Default radius in km for location-based buziness
 const DEFAULT_RADIUS = 20;
 
 export default function BuzinessEditScreen({
   editId,
 }: BuzinessEditScreenProps) {
+  const theme = useAppTheme();
   const { uid }: UserState = useSelector((state: RootState) => state.user);
   const dispatch = useDispatch();
-  const [categories, setCategories] = useState("");
+  const [categories, setCategories] = useState<string[]>([]);
   const [newBuziness, setNewBuziness] = useState<NewBuzinessInterface>({
     title: "",
     description: "",
   });
-  const [myContacts, setMyContacts] = useState<Option[]>([]);
-  const [contacts, setContacts] = useState<Optional<Tables<"contacts">, "id">[]>([]);
+  const [contacts, setContacts] = useState<Optional<Tables<"contacts">, "id">[]>(
+    [],
+  );
   const [defaultContact, setDefaultContact] = useState<number | undefined>();
 
   const [ingyen, setIngyen] = useState(false);
@@ -91,8 +80,8 @@ export default function BuzinessEditScreen({
     saveContacts: () => Promise<
       | PostgrestSingleResponse<unknown>
       | {
-        error: string;
-      }
+          error: string;
+        }
       | undefined
     >;
     getContacts: () => Optional<Tables<"contacts">, "id">[];
@@ -101,62 +90,62 @@ export default function BuzinessEditScreen({
   const [circle, setCircle] = useState<CircleType | undefined>(undefined);
   const selectedLocation = circle?.location || myLocation?.coords;
   const [loading, setLoading] = useState(false);
-  const [contactsExpanded, setContactsExpanded] = useState(false);
 
   const [mapModalVisible, setMapModalVisible] = useState(false);
-  const [tutorialVisible, setTutorialVisible] = useState(true);
+  const [helpVisible, setHelpVisible] = useState(false);
 
-  const title = newBuziness.title + " $ " + categories;
+  const title = [newBuziness.title, ...categories].join(" $ ");
+  const hasContact = contacts.some(
+    (c) => !!c && !!c.data && c.data.length > 0,
+  );
   const canSubmit = !!(
     newBuziness.title &&
-    categories &&
+    categories.length > 0 &&
     newBuziness.description &&
-    contacts.some((c) => !!c && !!c.data && c.data.length > 0)
+    hasContact
   );
-  useEffect(() => {
-    console.log("images", images);
-  }, [images]);
 
   const save = useCallback(async () => {
     setLoading(true);
     if (!uid) return;
 
-    // First save contacts
     const contactResponse = await contactEditRef.current?.saveContacts();
-    console.log("Contact save response:", contactResponse);
 
     if (contactResponse?.error) {
-      console.log("Error saving contacts:", contactResponse.error);
-      dispatch(addSnack({
-        title: "Hiba az elérhetőségek mentése során. Ellenőrizd a mezőket.",
-      }));
+      dispatch(
+        addSnack({
+          title:
+            "Hiba az elérhetőségek mentése során. Ellenőrizd a mezőket.",
+        }),
+      );
       setLoading(false);
       return;
     }
 
-    // Verify at least one contact exists
     const contactsCheck = await supabase
       .from("contacts")
       .select("id")
       .eq("author", uid);
 
     if (!contactsCheck.data || contactsCheck.data.length === 0) {
-      console.log("No contacts found for user");
-      dispatch(addSnack({
-        title: "Legalább egy elérhetőséget kötelező megadni a biznisz létrehozásához.",
-      }));
+      dispatch(
+        addSnack({
+          title:
+            "Legalább egy elérhetőséget kötelező megadni a biznisz létrehozásához.",
+        }),
+      );
       setLoading(false);
       return;
     }
-
-    console.log(selectedLocation);
 
     await supabase.functions
       .invoke("create-buziness", {
         body: {
           id: editId,
           ...newBuziness,
-          title,          ingyen,          author: uid,
+          title,
+          ingyen,
+          author: uid,
           location: selectedLocation
             ? `POINT(${selectedLocation?.longitude} ${selectedLocation?.latitude})`
             : null,
@@ -165,10 +154,10 @@ export default function BuzinessEditScreen({
       })
       .then(async (res) => {
         const buzinessId = editId ?? res.data?.id;
-        console.log(res, images.length, buzinessId);
         if (images.length && buzinessId) {
-          const newImages = await imagesUploadRef.current?.uploadImages(buzinessId);
-          console.log("uploadRes", newImages);
+          const newImages = await imagesUploadRef.current?.uploadImages(
+            buzinessId,
+          );
           if (uid && newImages)
             await supabase
               .from("buziness")
@@ -183,88 +172,59 @@ export default function BuzinessEditScreen({
                     }),
                   ) as string[],
               })
-              .eq("id", buzinessId)
-              .then((res) => {
-                console.log("images upsert", res);
-              });
-
-          //return images.filter((i, ind) => i && imagesRes?.[ind]?.error);
+              .eq("id", buzinessId);
         }
         setLoading(false);
         if (res.error) {
-          console.log(res.error);
-          dispatch(addSnack({
-            title: "Hiba történt a biznisz mentése során.",
-          }));
+          dispatch(
+            addSnack({ title: "Hiba történt a biznisz mentése során." }),
+          );
           return;
         }
-        console.log(res);
         router.navigate("/user");
       });
-  }, [defaultContact, dispatch, editId, images.length, newBuziness, selectedLocation, title, uid]);
+  }, [
+    defaultContact,
+    dispatch,
+    editId,
+    images.length,
+    ingyen,
+    newBuziness,
+    selectedLocation,
+    title,
+    uid,
+  ]);
 
   const saveRef = useRef(save);
-  useEffect(() => { saveRef.current = save; }, [save]);
-
   useEffect(() => {
-    if (circle) {
-      setMapModalVisible(false);
-    }
-  }, [circle]);
+    saveRef.current = save;
+  }, [save]);
 
-  // Function to reload contacts after saving
-  const reloadContacts = useCallback(() => {
-    if (uid) {
-      supabase
-        .from("contacts")
-        .select("*")
-        .eq("author", uid)
-        .then((res) => {
-          if (res.data) {
-            setContacts(res.data as Optional<Tables<"contacts">, "id">[]);
-            setMyContacts(
-              res.data.map((contact) => {
-                return {
-                  label: contact.data,
-                  value: contact.id.toString(),
-                };
-              }),
-            );
-          }
-        });
-    }
+  const loadContacts = useCallback(() => {
+    if (!uid) return;
+    supabase
+      .from("contacts")
+      .select("*")
+      .eq("author", uid)
+      .then((res) => {
+        if (res.data) {
+          setContacts(res.data as Optional<Tables<"contacts">, "id">[]);
+        }
+      });
   }, [uid]);
 
-  useEffect(() => {
+  const handleSavePress = useCallback(async () => {
     dispatch(
-      setOptions([
-        {
-          title: "Mentés",
-          icon: "content-save",
-          disabled: !canSubmit || loading,
-          onPress: async () => {
-            dispatch(
-              showLoading({
-                dismissable: false,
-                title: "Kérlek várj, amíg a bizniszed feltöltődik",
-              }),
-            );
-            await saveRef.current();
-            dispatch(hideLoading());
-            reloadContacts();
-          },
-        },
-      ]),
+      showLoading({
+        dismissable: false,
+        title: "Kérlek várj, amíg a bizniszed feltöltődik",
+      }),
     );
-    return () => {
-      dispatch(clearOptions());
-    };
-  }, [canSubmit, dispatch, save, loading, reloadContacts]);
+    await saveRef.current();
+    dispatch(hideLoading());
+    loadContacts();
+  }, [dispatch, loadContacts]);
 
-  useEffect(() => {
-    console.log("contacts", contacts);
-
-  }, [contacts]);
   useFocusEffect(
     useCallback(() => {
       if (editId && uid) {
@@ -286,8 +246,7 @@ export default function BuzinessEditScreen({
                 editingBuziness.title
                   .split(" $ ")
                   .slice(1)
-                  .reduce((partialSum, a) => partialSum + " $ " + a, "") +
-                " $ ",
+                  .filter(Boolean),
               );
               setIngyen(!!editingBuziness.ingyen);
               if (editingBuziness.defaultContact)
@@ -307,276 +266,247 @@ export default function BuzinessEditScreen({
             }
           });
       }
-      if (uid) {
-
-        supabase
-          .from("contacts")
-          .select("*")
-          .eq("author", uid)
-          .then((res) => {
-            if (res.data) {
-              setContacts(res.data as Optional<Tables<"contacts">, "id">[]);
-              setMyContacts(
-                res.data.map((contact) => {
-                  return {
-                    label: contact.data,
-                    value: contact.id.toString(),
-                  };
-                }),
-              );
-              // If no contacts exist, expand the contacts section by default
-              if (res.data.length === 0) {
-                setContactsExpanded(true);
-              }
-            }
-          });
-      }
-
-      return () => {
-        console.log("This route is now unfocused.");
-      };
-    }, [editId, navigation, uid]),
+      loadContacts();
+    }, [editId, uid, loadContacts]),
   );
+
+  const surfaceStyle = {
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.lg,
+    gap: Spacing.md,
+  };
+
   return (
     <>
-      {editId && <Stack.Screen options={{ title: "Biznisz szerkesztése" }} />}
+      <Stack.Screen
+        options={{ title: editId ? "Biznisz szerkesztése" : "Új Biznisz" }}
+      />
       <ThemedView style={{ flex: 1 }}>
-        <ScrollView style={{ flex: 1 }} contentContainerStyle={{}}>
-          {tutorialVisible && (
-            <Card
-              mode="elevated"
-              style={{ borderTopLeftRadius: 0, borderTopRightRadius: 0 }}
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{
+            paddingHorizontal: Spacing.md,
+            paddingTop: Spacing.lg,
+            paddingBottom: Spacing.xxl,
+            gap: Spacing.lg,
+          }}
+        >
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              gap: Spacing.sm,
+              paddingHorizontal: Spacing.xs,
+            }}
+          >
+            <Text
+              variant="bodyMedium"
+              style={{ flex: 1, color: theme.colors.onSurfaceVariant }}
             >
-              <Card.Title
-                title={"Mihez értesz?"}
-                right={() => (
-                  <IconButton
-                    icon="close"
-                    onPress={() => setTutorialVisible(false)}
-                  />
-                )}
+              Oszd meg, miben tudsz másoknak segíteni.
+            </Text>
+            <IconButton
+              icon="help-circle-outline"
+              size={22}
+              onPress={() => setHelpVisible(true)}
+              accessibilityLabel="Mi ez az oldal?"
+            />
+          </View>
+
+          <View style={{ gap: Spacing.sm }}>
+            <SectionLabel label="Alapadatok" />
+            <Surface elevation={1} style={surfaceStyle}>
+              <TextInput
+                mode="outlined"
+                label="Biznisz neve *"
+                value={newBuziness.title}
+                onChangeText={(t) =>
+                  setNewBuziness({ ...newBuziness, title: t })
+                }
               />
-              <Card.Content>
-                {tutorialVisible && (
-                  <Text>
-                    Ezen az oldalon fel tudsz venni egy új bizniszt a profilodba.
-                    {"\n"}A te bizniszeid azon hobbijaid, képességeid vagy
-                    szakmáid listája, amelyeket meg szeretnél osztani másokkal is.{" "}
-                    {"\n"}Ha, mondjuk, futószalagon gyártod a sütiket, és
-                    ezt felveszed a bizniszeid közé, a Biznisz oldalon
-                    megtalálható leszel a süti kulcsszóval.
-                  </Text>
-                )}
-              </Card.Content>
-            </Card>
-          )}
-          <View style={{}}>
-            <TextInput
-              placeholder="Bizniszem neve"
-              value={newBuziness.title}
-              onChangeText={(t) => setNewBuziness({ ...newBuziness, title: t })}
-            />
-            <TagInput
-              placeholder="Kategóriák, nyomj entert a hozzáadásukhoz"
-              onChange={setCategories}
-              value={categories}
-            />
-            <TextInput
-              placeholder="Fejtsd ki bővebben"
-              value={newBuziness.description}
-              multiline
-              onChangeText={(t) =>
-                setNewBuziness({ ...newBuziness, description: t })
-              }
-            />
-            <Dropdown
-              label="Kiemelt elérhetőséged"
-              options={myContacts}
-              value={defaultContact?.toString() ?? ""}
-              CustomDropdownInput={({
-                placeholder,
-                selectedLabel,
-                label,
-                rightIcon,
-              }: DropdownInputProps) => (
-                <TextInput
-                  placeholder={placeholder}
-                  label={label}
-                  value={selectedLabel ?? ""}
-                  right={rightIcon}
-                />
-              )}
-              CustomDropdownItem={({
-                option,
-                value,
-                onSelect,
-                toggleMenu,
-                isLast,
-              }) => {
-                return (
-                  <>
-                    <TouchableRipple
-                      onPress={() => {
-                        onSelect?.(option.value);
-                        toggleMenu();
-                      }}
-                    >
-                      <Headline
-                        style={{
-                          color:
-                            value === option.value
-                              ? MD3DarkTheme.colors.onPrimary
-                              : MD3DarkTheme.colors.primary,
-                          alignItems: "center",
-                          display: "flex",
-                          padding: Spacing.sm,
-                        }}
+              <TextInput
+                mode="outlined"
+                label="Leírás *"
+                value={newBuziness.description}
+                multiline
+                numberOfLines={4}
+                onChangeText={(t) =>
+                  setNewBuziness({ ...newBuziness, description: t })
+                }
+              />
+            </Surface>
+          </View>
+
+          <View style={{ gap: Spacing.sm }}>
+            <SectionLabel label="Kulcsszavak" required />
+            <Surface elevation={1} style={surfaceStyle}>
+              <TagInput
+                placeholder="Új kulcsszó…"
+                onChange={setCategories}
+                value={categories}
+              />
+              <HelperText type="info" visible style={{ paddingLeft: 0 }}>
+                Pl. süti, kerékpár, programozás
+              </HelperText>
+            </Surface>
+          </View>
+
+          <View style={{ gap: Spacing.sm }}>
+            <SectionLabel label="Elérhetőségek" required />
+            <Surface elevation={1} style={surfaceStyle}>
+              <Text
+                variant="bodyMedium"
+                style={{ color: theme.colors.onSurfaceVariant }}
+              >
+                Töltsd ki azt, ahol elérhetnek. A csillaggal jelölheted a
+                legfontosabbat.
+              </Text>
+              <ContactEditScreen
+                ref={contactEditRef}
+                onContactsChange={(newContacts) => setContacts(newContacts)}
+                defaultContactId={defaultContact}
+                onDefaultContactChange={setDefaultContact}
+                showFeaturedToggle
+              />
+            </Surface>
+            {!hasContact && (
+              <HelperText
+                type="error"
+                visible
+                style={{ paddingLeft: Spacing.xs }}
+              >
+                Legalább egy elérhetőség megadása kötelező.
+              </HelperText>
+            )}
+          </View>
+
+          <View style={{ gap: Spacing.sm }}>
+            <SectionLabel label="Hol érhető el a bizniszed?" />
+            <Surface elevation={1} style={surfaceStyle}>
+              <SegmentedButtons
+                value={!circle ? "net" : "map"}
+                onValueChange={(v) => {
+                  if (v === "net") setCircle(undefined);
+                  else setMapModalVisible(true);
+                }}
+                buttons={[
+                  { value: "net", label: "Bárhol", icon: "wifi" },
+                  { value: "map", label: "Térképen", icon: "map-marker" },
+                ]}
+              />
+              {circle ? (
+                <View
+                  style={{
+                    borderRadius: BorderRadius.md,
+                    overflow: "hidden",
+                    height: 200,
+                  }}
+                >
+                  <FiFeMap
+                    zoomControlEnabled={false}
+                    initialCamera={{
+                      center:
+                        selectedLocation || myLocation?.coords || undefined,
+                    }}
+                    style={{ width: "100%", height: 200 }}
+                    moveOnMarkerPress
+                  >
+                    {(!!selectedLocation || !!myLocation) && (
+                      <Marker
+                        coordinate={
+                          selectedLocation ||
+                          myLocation?.coords || {
+                            latitude: 47.4979,
+                            longitude: 19.0402,
+                          }
+                        }
+                        anchor={{ x: 0.5, y: 0.5 }}
                       >
-                        <Icon source={typeToIcon(option.label) || "dots-horizontal"} size={22} />
-                        <ThemedText style={{ marginLeft: Spacing.sm }}>
-                          {option.label}
-                        </ThemedText>
-                      </Headline>
-                    </TouchableRipple>
-                    {!isLast && <Divider />}
-                  </>
-                );
-              }}
-              hideMenuHeader
-              onSelect={(e) => {
-                setDefaultContact(Number(e));
-              }}
-            />
-            <List.Item
-              title="Ingyenes / önkéntes biznisz"
-              description="Jelöld be, ha ingyenesen vagy önkéntesen végzed"
-              style={{ marginTop: Spacing.sm }}
-              right={() => (
-                <Switch value={ingyen} onValueChange={setIngyen} />
+                        <NewMarkerIcon width={24} height={24} />
+                      </Marker>
+                    )}
+                  </FiFeMap>
+                </View>
+              ) : (
+                <Text
+                  variant="bodyMedium"
+                  style={{ color: theme.colors.onSurfaceVariant }}
+                >
+                  A bizniszed bárhonnan elérhető — nincs földrajzi helyhez
+                  kötve.
+                </Text>
               )}
-            />
-            <List.Item
-              title="Elérhetőségek"
-              style={{ marginTop: Spacing.sm }}
-              description="Legalább egy elérhetőség megadása kötelező"
-              onPress={() => setContactsExpanded(!contactsExpanded)}
-              left={(props) => <List.Icon {...props} icon="contacts" />}
-              right={() =>
-                !contacts.some((c) => !!c && !!c.data && c.data.length > 0) ? (
-                  <View style={{ flexDirection: "row", alignItems: "center" }}>
-                    <Icon source="alert-circle" size={20} color={theme.colors.error} />
-                  </View>
-                ) : <List.Icon icon={contactsExpanded ? "chevron-up" : "chevron-down"} />
-              }
-            />
-            <View style={{ display: contactsExpanded ? "flex" : "none" }}>
-              <ContactEditScreen ref={contactEditRef} onContactsChange={(newContacts) => setContacts(newContacts)} style={{ padding: Spacing.lg, paddingRight: 0, }} />
-            </View>
-            <Divider style={{ marginTop: Spacing.sm, marginBottom: Spacing.sm }} />
-            <BuzinessImageUpload
-              images={images}
-              setImages={setImages}
-              buzinessId={editId}
-              ref={imagesUploadRef}
-            />
-            {(
+              {circle && (
+                <Button
+                  mode="contained-tonal"
+                  onPress={() => setMapModalVisible(true)}
+                >
+                  Környék módosítása
+                </Button>
+              )}
+            </Surface>
+          </View>
+
+          <View style={{ gap: Spacing.sm }}>
+            <SectionLabel label="Képek" optional />
+            <Surface elevation={1} style={surfaceStyle}>
+              <BuzinessImageUpload
+                images={images}
+                setImages={setImages}
+                buzinessId={editId}
+                ref={imagesUploadRef}
+              />
+            </Surface>
+          </View>
+
+          <View style={{ gap: Spacing.sm }}>
+            <SectionLabel label="Beállítások" />
+            <Surface elevation={1} style={surfaceStyle}>
               <View
                 style={{
                   flexDirection: "row",
-                  flexWrap: "wrap",
-                  justifyContent: "space-between",
                   alignItems: "center",
-                  padding: Spacing.sm,
+                  gap: Spacing.md,
                 }}
               >
-                <ThemedText>A bizniszed helyzete</ThemedText>
-
-                <SegmentedButtons
-                  value={!circle ? "net" : "map"}
-                  style={{ width: 300 }}
-                  onValueChange={
-                    (v) => {
-                      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-                      v == "net" ?
-                        setCircle(undefined) :
-                        setMapModalVisible(true);
-                    }}
-                  buttons={[
-                    {
-                      value: "net",
-                      label: "Bárhol",
-                      icon: "wifi"
-                    },
-                    {
-                      value: "map",
-                      label: "Térképen",
-                      icon: "map-marker"
-                    },
-                  ]}
+                <Icon
+                  source="charity"
+                  size={24}
+                  color={theme.colors.primary}
+                />
+                <View style={{ flex: 1, gap: 2 }}>
+                  <Text variant="bodyMedium">Ingyenes / önkéntes biznisz</Text>
+                  <Text
+                    variant="bodyMedium"
+                    style={{ color: theme.colors.onSurfaceVariant }}
+                  >
+                    Jelöld be, ha ingyenesen vagy önkéntesen végzed.
+                  </Text>
+                </View>
+                <Switch
+                  value={ingyen}
+                  onValueChange={setIngyen}
+                  color={theme.colors.nature}
                 />
               </View>
-            )}
-            <View style={{ minHeight: circle ? 300 : 100 }}>
-              {circle ? (
-                <FiFeMap
-                  zoomControlEnabled={false}
-                  initialCamera={{
-                    center: selectedLocation ||
-                      myLocation?.coords || undefined,
-                  }}
-                  style={{ width: "100%", height: 300 }}
-                  moveOnMarkerPress
-                >
-                  {(!!selectedLocation || !!myLocation) && (
-                    <Marker
-                      coordinate={
-                        selectedLocation ||
-                        myLocation?.coords || {
-                          latitude: 47.4979,
-                          longitude: 19.0402,
-                        }
-                      }
-                      anchor={{ x: 0.5, y: 0.5 }}
-                    >
-                      <NewMarkerIcon width={24} height={24} />
-                    </Marker>
-                  )}
-                </FiFeMap>
-              ) : (
-                <View style={{ alignItems: "center", gap: Spacing.sm, padding: Spacing.lg }}>
-                  <Image
-                    style={{ width: 100, height: 100 }}
-                    source={require("@/assets/images/img-map.png")}
-                  />
-                  <ThemedText type="subtitle">
-                    Találjanak meg a helyiek
-                  </ThemedText>
-                  <Button
-                    onPress={() => setMapModalVisible(true)}
-                    mode={"contained-tonal"}
-                  >
-                    Válassz környéket
-                  </Button>
-                </View>
-              )}
-            </View>
+            </Surface>
           </View>
-          <ThemedView
-            type="default"
-            style={{
-              padding: Spacing.sm,
-              bottom: 0,
-              width: "100%",
-              gap: Spacing.lg
-            }}
-          >
-            <ThemedText>Így fog megjelenni a bizniszed:</ThemedText>
+
+          <View style={{ gap: Spacing.sm }}>
+            <SectionLabel label="Így fog megjelenni" />
             <BuzinessItem
+              preview
               data={{
                 id: editId || 0,
                 author: uid || "",
-                title: ((newBuziness.title || "A biznisz címe") + (categories ? " $ " + categories : " $ Egy kategória $ Egy másik kategória")),
-                description: newBuziness.description || "Hosszabb leírás hogy miről szól a bizniszed.",
+                title:
+                  (newBuziness.title || "A biznisz címe") +
+                  (categories.length
+                    ? " $ " + categories.join(" $ ")
+                    : " $ Egy kategória $ Egy másik kategória"),
+                description:
+                  newBuziness.description ||
+                  "Hosszabb leírás hogy miről szól a bizniszed.",
                 images: images,
                 location: circle
                   ? `POINT(${circle.location.longitude} ${circle.location.latitude})`
@@ -584,28 +514,43 @@ export default function BuzinessEditScreen({
                 recommendations: 0,
               }}
             />
-            <View style={{ alignItems: "flex-end" }}>
-              <Button mode="contained" onPress={async () => {
-                dispatch(showLoading({ dismissable: false, title: "Kérlek várj, amíg a bizniszed feltöltődik" }));
-                await saveRef.current();
-                dispatch(hideLoading());
-                reloadContacts();
-              }} disabled={!canSubmit || loading}>Mentés</Button>
-            </View>
-          </ThemedView>
+          </View>
         </ScrollView>
+
+        <Surface
+          elevation={2}
+          style={{
+            paddingHorizontal: Spacing.lg,
+            paddingVertical: Spacing.md,
+            borderTopWidth: 1,
+            borderTopColor: theme.colors.outlineVariant,
+            flexDirection: "row",
+          }}
+        >
+          <Button
+            mode="contained"
+            icon="check-bold"
+            disabled={!canSubmit || loading}
+            onPress={handleSavePress}
+            style={{ flex: 1, borderRadius: BorderRadius.lg }}
+            contentStyle={{ height: 56 }}
+            labelStyle={{ fontFamily: "RedHatText-Bold" }}
+          >
+            Mentés
+          </Button>
+        </Surface>
+
         <Portal>
           <Modal
             visible={mapModalVisible}
-            onDismiss={() => {
-              setMapModalVisible(false);
-            }}
+            onDismiss={() => setMapModalVisible(false)}
             style={{ alignItems: "center" }}
             contentContainerStyle={[
               {
                 width: "90%",
                 height: "90%",
-              }]}
+              },
+            ]}
             dismissableBackButton
           >
             <ThemedView style={containerStyle.containerStyle}>
@@ -618,6 +563,26 @@ export default function BuzinessEditScreen({
               />
             </ThemedView>
           </Modal>
+
+          <Dialog
+            visible={helpVisible}
+            onDismiss={() => setHelpVisible(false)}
+          >
+            <Dialog.Title>Mihez értesz?</Dialog.Title>
+            <Dialog.Content>
+              <Text variant="bodyMedium">
+                Ezen az oldalon fel tudsz venni egy új bizniszt a profilodba.
+                {"\n\n"}A te bizniszeid azon hobbijaid, képességeid vagy
+                szakmáid listája, amelyeket meg szeretnél osztani másokkal is.
+                {"\n\n"}Ha, mondjuk, futószalagon gyártod a sütiket, és ezt
+                felveszed a bizniszeid közé, a Biznisz oldalon megtalálható
+                leszel a süti kulcsszóval.
+              </Text>
+            </Dialog.Content>
+            <Dialog.Actions>
+              <Button onPress={() => setHelpVisible(false)}>Értem</Button>
+            </Dialog.Actions>
+          </Dialog>
         </Portal>
       </ThemedView>
     </>

--- a/components/buziness/BuzinessImageUpload.tsx
+++ b/components/buziness/BuzinessImageUpload.tsx
@@ -3,13 +3,21 @@ import { RootState } from "@/redux/store";
 import { ImageDataType, UserState } from "@/redux/store.type";
 import * as ExpoImagePicker from "expo-image-picker";
 import { useImperativeHandle, useState } from "react";
-import { ScrollView, useWindowDimensions, View } from "react-native";
-import ImageModal from "react-native-image-modal";
-import { IconButton, TextInput } from "react-native-paper";
+import { Image, Pressable, ScrollView, View } from "react-native";
+import {
+  Button,
+  IconButton,
+  Modal,
+  Portal,
+  Text,
+  TextInput,
+} from "react-native-paper";
 import { useSelector } from "react-redux";
-import { ThemedText } from "../ThemedText";
 import { Spacing } from "@/constants/spacing";
+import { BorderRadius } from "@/constants/borderRadius";
 import { useAppTheme } from "@/assets/theme";
+
+const TILE_SIZE = 110;
 
 export interface BuzinessImageUploadHandle {
   uploadImages: (buziessId: number) => Promise<ImageDataType[]>;
@@ -21,8 +29,15 @@ interface BuzinessImageUploadProps {
   ref?: React.Ref<BuzinessImageUploadHandle>;
 }
 
-const BuzinessImageUpload = ({ images, setImages, buzinessId, ref }: BuzinessImageUploadProps) => {
+const BuzinessImageUpload = ({
+  images,
+  setImages,
+  buzinessId,
+  ref,
+}: BuzinessImageUploadProps) => {
   const theme = useAppTheme();
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+
   useImperativeHandle(ref, () => ({
     uploadImages: async (buzinessId: number) => {
       const uploadPromises = images.map(async (i) => {
@@ -37,15 +52,12 @@ const BuzinessImageUpload = ({ images, setImages, buzinessId, ref }: BuzinessIma
       return Promise.all(uploadPromises);
     },
   }));
-  const { width: w } = useWindowDimensions();
-  const width = w * 0.8;
+
   const { uid: myUid }: UserState = useSelector(
     (state: RootState) => state.user,
   );
-  const [loading, setLoading] = useState(false);
 
   const pickImage = async () => {
-    setLoading(true);
     const result = await ExpoImagePicker.launchImageLibraryAsync({
       mediaTypes: ExpoImagePicker.MediaTypeOptions.Images,
       allowsEditing: true,
@@ -56,7 +68,6 @@ const BuzinessImageUpload = ({ images, setImages, buzinessId, ref }: BuzinessIma
     });
 
     if (result && !result?.canceled) {
-      console.log(result);
       setImages([
         ...images,
         {
@@ -66,9 +77,9 @@ const BuzinessImageUpload = ({ images, setImages, buzinessId, ref }: BuzinessIma
           status: "toUpload",
         },
       ]);
-    } else console.log("cancelled");
-    setLoading(false);
+    }
   };
+
   const uploadImage = async (
     image: ExpoImagePicker.ImagePickerAsset,
     buzinessId: number,
@@ -83,10 +94,7 @@ const BuzinessImageUpload = ({ images, setImages, buzinessId, ref }: BuzinessIma
 
     let uploadData: Uint8Array | Blob;
     if (image.base64) {
-      // Use base64 directly — avoids fetch failures on iOS temp file URIs.
-      // Pass Uint8Array (ArrayBufferView), not .buffer — ArrayBuffer can be
-      // detached crossing the Hermes JSI bridge on iOS.
-      const b64 = image.base64.replace(/\s/g, ""); // strip any line breaks
+      const b64 = image.base64.replace(/\s/g, "");
       const binaryString = atob(b64);
       const bytes = new Uint8Array(binaryString.length);
       for (let i = 0; i < binaryString.length; i++) {
@@ -115,6 +123,7 @@ const BuzinessImageUpload = ({ images, setImages, buzinessId, ref }: BuzinessIma
 
     return upload?.data?.path;
   };
+
   const deleteImage = async (image: ImageDataType, buzinessId: number) => {
     const deleteRes = await supabase.storage
       .from("buzinessImages")
@@ -124,98 +133,234 @@ const BuzinessImageUpload = ({ images, setImages, buzinessId, ref }: BuzinessIma
       setImages(images.filter((i) => i.path !== image.path));
     return;
   };
-  const toDeleteImage = async (ind: number, undo?: boolean) => {
-    console.log("delete", buzinessId, images[ind], ind);
 
-    if (buzinessId) {
-      setImages(
-        images
-          .filter((i, ind2) => i.path || ind2 !== ind)
-          .map((i, ind2) =>
-            ind2 !== ind ? i : { ...i, status: undo ? "uploaded" : "toDelete" },
-          ) as ImageDataType[],
-      );
+  const toggleDelete = (ind: number) => {
+    if (!buzinessId) {
+      setImages(images.filter((_, ind2) => ind2 !== ind));
+      return;
     }
+    const target = images[ind];
+    if (!target) return;
+    if (target.status === "toUpload") {
+      setImages(images.filter((_, ind2) => ind2 !== ind));
+      return;
+    }
+    setImages(
+      images.map((i, ind2) =>
+        ind2 !== ind
+          ? i
+          : {
+              ...i,
+              status: i.status === "toDelete" ? "uploaded" : "toDelete",
+            },
+      ) as ImageDataType[],
+    );
   };
+
+  const setDescription = (ind: number, text: string) => {
+    setImages(
+      images.map((i, ind2) =>
+        ind2 === ind ? { ...i, description: text } : i,
+      ),
+    );
+  };
+
+  const editingImage = editingIndex !== null ? images[editingIndex] : null;
+
   return (
     <View>
-      <ThemedText style={{ padding: Spacing.sm }}>Képek feltöltése</ThemedText>
       <ScrollView
         horizontal
-        contentContainerStyle={{ alignItems: "center", gap: Spacing.xs }}
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ gap: Spacing.sm, paddingVertical: Spacing.xs }}
       >
         {images.map((image, ind) => {
+          const isMarkedForDeletion = image.status === "toDelete";
           return (
-            <View
-              key={"image-" + ind}
-              style={{
-                width: width,
-                backgroundColor:
-                  image.status === "toDelete" ? theme.colors.error : "transparent",
-              }}
-            >
-              {image.status === "toDelete" && (
-                <>
-                  <ThemedText
-                    style={{
-                      position: "absolute",
-                      top: 100,
-                      width,
-                      zIndex: 10,
-                      textAlign: "center",
-                      color: theme.colors.onError,
-                    }}
-                  >
-                    Törlésre kijelölve
-                  </ThemedText>
+            <View key={"image-" + ind} style={{ width: TILE_SIZE, gap: Spacing.xs }}>
+              <Pressable
+                onPress={() => setEditingIndex(ind)}
+                style={{
+                  width: TILE_SIZE,
+                  height: TILE_SIZE,
+                  borderRadius: BorderRadius.lg,
+                  overflow: "hidden",
+                  backgroundColor: theme.colors.surfaceVariant,
+                }}
+              >
+                <Image
+                  source={{ uri: image.url }}
+                  style={{
+                    width: TILE_SIZE,
+                    height: TILE_SIZE,
+                    opacity: isMarkedForDeletion ? 0.35 : 1,
+                  }}
+                  resizeMode="cover"
+                />
+                {isMarkedForDeletion && (
                   <View
                     style={{
                       position: "absolute",
-                      top: 0,
-                      left: 0,
-                      width,
-                      height: 200,
-                      zIndex: 1,
-                      backgroundColor: theme.colors.error,
-                      opacity: 0.4,
+                      inset: 0,
+                      alignItems: "center",
+                      justifyContent: "center",
                     }}
+                  >
+                    <Text
+                      variant="labelSmall"
+                      style={{
+                        color: theme.colors.onError,
+                        backgroundColor: theme.colors.error,
+                        paddingHorizontal: Spacing.sm,
+                        paddingVertical: Spacing.xs,
+                        borderRadius: BorderRadius.xs,
+                        overflow: "hidden",
+                      }}
+                    >
+                      Törlésre kijelölve
+                    </Text>
+                  </View>
+                )}
+                <View
+                  style={{
+                    position: "absolute",
+                    top: Spacing.xs,
+                    right: Spacing.xs,
+                    borderRadius: BorderRadius.full,
+                    backgroundColor: theme.colors.surface,
+                  }}
+                >
+                  <IconButton
+                    icon={isMarkedForDeletion ? "delete-off" : "close"}
+                    size={14}
+                    onPress={(e) => {
+                      e.stopPropagation?.();
+                      toggleDelete(ind);
+                    }}
+                    style={{ margin: 0 }}
+                    accessibilityLabel={
+                      isMarkedForDeletion
+                        ? "Törlés visszavonása"
+                        : "Kép eltávolítása"
+                    }
                   />
-                </>
+                </View>
+              </Pressable>
+              {!!image.description && (
+                <Text
+                  variant="labelSmall"
+                  numberOfLines={2}
+                  style={{ color: theme.colors.onSurfaceVariant }}
+                >
+                  {image.description}
+                </Text>
               )}
-              <ImageModal
-                resizeMode="cover"
-                modalImageResizeMode="contain"
-                overlayBackgroundColor="#00000066"
-                source={{ uri: image.url }}
-                style={{ width: width, height: 200 }}
-              />
-              <TextInput
-                style={{ width: width }}
-                value={images[ind]?.description || ""}
-                multiline
-                placeholder="Mesélj erről a képről"
-                onChangeText={(text) => {
-                  setImages(
-                    images.map((i, ind2) => {
-                      return ind2 === ind ? { ...i, description: text } : i;
-                    }),
-                  );
-                }}
-              />
-              <IconButton
-                mode="contained-tonal"
-                icon={image.status === "toDelete" ? "delete-off" : "delete"}
-                onPress={() => {
-                  toDeleteImage(ind, image.status === "toDelete");
-                }}
-                style={{ position: "absolute", zIndex: 2, top: 0, right: 0 }}
-              />
             </View>
           );
         })}
-        <IconButton icon="plus" onPress={pickImage} mode="contained" iconColor={theme.colors.onSurface} />
+
+        <Pressable
+          onPress={pickImage}
+          style={{
+            width: TILE_SIZE,
+            height: TILE_SIZE,
+            borderRadius: BorderRadius.lg,
+            borderWidth: 1.5,
+            borderStyle: "dashed",
+            borderColor: theme.colors.outline,
+            alignItems: "center",
+            justifyContent: "center",
+            gap: Spacing.xs,
+            backgroundColor: theme.colors.surfaceVariant,
+          }}
+          accessibilityLabel="Kép hozzáadása"
+        >
+          <IconButton
+            icon="plus"
+            size={28}
+            iconColor={theme.colors.onSurfaceVariant}
+            style={{ margin: 0 }}
+            disabled
+          />
+          <Text
+            variant="labelSmall"
+            style={{ color: theme.colors.onSurfaceVariant }}
+          >
+            Hozzáadás
+          </Text>
+        </Pressable>
       </ScrollView>
+
+      <Portal>
+        <Modal
+          visible={editingIndex !== null}
+          onDismiss={() => setEditingIndex(null)}
+          contentContainerStyle={{
+            backgroundColor: theme.colors.surface,
+            marginHorizontal: Spacing.lg,
+            borderRadius: BorderRadius.lg,
+            padding: Spacing.lg,
+            gap: Spacing.md,
+          }}
+        >
+          {editingImage && editingIndex !== null && (
+            <>
+              <Image
+                source={{ uri: editingImage.url }}
+                style={{
+                  width: "100%",
+                  height: 240,
+                  borderRadius: BorderRadius.md,
+                  backgroundColor: theme.colors.surfaceVariant,
+                }}
+                resizeMode="contain"
+              />
+              <TextInput
+                mode="outlined"
+                label="Leírás"
+                placeholder="Mesélj erről a képről"
+                value={editingImage.description || ""}
+                onChangeText={(t) =>
+                  setDescription(editingIndex, t.replace(/\r?\n/g, " "))
+                }
+              />
+              <View
+                style={{
+                  flexDirection: "row",
+                  justifyContent: "flex-end",
+                  gap: Spacing.sm,
+                }}
+              >
+                <Button
+                  mode="outlined"
+                  textColor={theme.colors.error}
+                  icon={
+                    editingImage.status === "toDelete"
+                      ? "delete-off"
+                      : "delete"
+                  }
+                  onPress={() => {
+                    toggleDelete(editingIndex);
+                    setEditingIndex(null);
+                  }}
+                >
+                  {editingImage.status === "toDelete"
+                    ? "Visszaállítás"
+                    : "Törlés"}
+                </Button>
+                <Button
+                  mode="contained"
+                  onPress={() => setEditingIndex(null)}
+                >
+                  Kész
+                </Button>
+              </View>
+            </>
+          )}
+        </Modal>
+      </Portal>
     </View>
   );
 };
+
 export default BuzinessImageUpload;

--- a/components/buziness/BuzinessItem.tsx
+++ b/components/buziness/BuzinessItem.tsx
@@ -23,9 +23,10 @@ import { useAppTheme } from "@/assets/theme";
 interface BuzinessItemProps {
   data: BuzinessItemInterface;
   showOptions?: boolean;
+  preview?: boolean;
 }
 
-const BuzinessItem = ({ data, showOptions }: BuzinessItemProps) => {
+const BuzinessItem = ({ data, showOptions, preview }: BuzinessItemProps) => {
   const { author, title: titleAndCats, description, id } = data;
 
   const recommendations = typeof data?.recommendations?.[0]?.count === "number" ? data?.recommendations?.[0]?.count : data.recommendations;
@@ -75,10 +76,8 @@ const BuzinessItem = ({ data, showOptions }: BuzinessItemProps) => {
     );
   };
 
-  return (
-    <Link href={{ pathname: "/biznisz/[id]", params: { id: id } }} asChild>
-      <Pressable>
-        <Surface style={styles.container} elevation={2} mode="flat">
+  const card = (
+    <Surface style={styles.container} elevation={2} mode="flat">
           <View style={{ flexDirection: "row" }}>
             <View style={{ flex: 1 }}>
               <Text variant="titleLarge" style={{ fontSize: 18, lineHeight: 24 }}>{title}</Text>
@@ -122,7 +121,13 @@ const BuzinessItem = ({ data, showOptions }: BuzinessItemProps) => {
             </View>
           )}
         </Surface>
-      </Pressable>
+  );
+
+  if (preview) return card;
+
+  return (
+    <Link href={{ pathname: "/biznisz/[id]", params: { id: id } }} asChild>
+      <Pressable>{card}</Pressable>
     </Link>
   );
 };

--- a/components/buziness/ContactEditScreen.tsx
+++ b/components/buziness/ContactEditScreen.tsx
@@ -16,9 +16,11 @@ import React, {
   forwardRef,
 } from "react";
 import { StyleProp, View, ViewStyle } from "react-native";
-import { Icon, TextInput } from "react-native-paper";
+import { Button, IconButton, Menu, TextInput } from "react-native-paper";
 import { useDispatch, useSelector } from "react-redux";
 import { Spacing } from "@/constants/spacing";
+import { BorderRadius } from "@/constants/borderRadius";
+import { useAppTheme } from "@/assets/theme";
 
 const types: {
   label: string;
@@ -40,6 +42,9 @@ type IContact = Optional<Tables<"contacts">, "id">;
 type ContactEditScreenProps = {
   onContactsChange?: (contacts: IContact[]) => void;
   style?: StyleProp<ViewStyle>;
+  defaultContactId?: number;
+  onDefaultContactChange?: (id: number | undefined) => void;
+  showFeaturedToggle?: boolean;
 };
 
 const ContactEditScreen = forwardRef<{
@@ -54,29 +59,38 @@ const ContactEditScreen = forwardRef<{
     text: string;
   } | null>(null);
   const { uid } = useSelector((state: RootState) => state.user);
+  const theme = useAppTheme();
 
   const dispatch = useDispatch();
   const [contacts, setContacts] = useState<IContact[]>([]);
   const [buzinessCount, setBuzinessCount] = useState(0);
+  const [revealedTypes, setRevealedTypes] = useState<Enums<"contact_type">[]>([
+    "TEL",
+  ]);
+  const [addMenuVisible, setAddMenuVisible] = useState(false);
   const loadContacts = () => {
-    if (uid) {
-      supabase
-        .from("contacts")
-        .select("*")
-        .eq("author", uid)
-        .then((res) => {
-          if (res.data?.length) setContacts(res.data);
-          setLoading(false);
-        });
-
+    if (!uid) return;
+    Promise.all([
+      supabase.from("contacts").select("*").eq("author", uid),
       supabase
         .from("buziness")
         .select("id", { count: "exact", head: true })
-        .eq("author", uid).then((res) => {
-          // If no buziness exists, prefill with one empty contact
-          setBuzinessCount(res.count || 0);
+        .eq("author", uid),
+    ]).then(([contactsRes, buzinessRes]) => {
+      if (contactsRes.data?.length) {
+        setContacts(contactsRes.data);
+        setRevealedTypes((prev) => {
+          const next = new Set<Enums<"contact_type">>(prev);
+          next.add("TEL");
+          contactsRes.data.forEach((c) => {
+            if (c.data && c.data.length > 0) next.add(c.type);
+          });
+          return Array.from(next);
         });
-    }
+      }
+      setBuzinessCount(buzinessRes.count || 0);
+      setLoading(false);
+    });
   };
 
   useEffect(() => {
@@ -170,54 +184,140 @@ const ContactEditScreen = forwardRef<{
       return contacts;
     },
   }));
+  const hiddenTypes = types.filter((t) => !revealedTypes.includes(t.value));
+
   return (
-    <View style={[{ flex: 1, gap: Spacing.sm }, props?.style]}>
+    <View style={[{ flex: 1, gap: Spacing.md }, props?.style]}>
       {!loading &&
-        types.map((type, ind) => {
+        types
+          .filter((type) => revealedTypes.includes(type.value))
+          .map((type, ind) => {
           const current = {
             title: "",
             data: "",
             ...contacts.find((c) => c?.type === type.value),
           };
+          const filled = !!current.data;
+          const isFeatured =
+            props.showFeaturedToggle &&
+            typeof current.id === "number" &&
+            props.defaultContactId === current.id;
+          // saveContact still expects an index into the full `types` array
+          const typeIndex = types.findIndex((t) => t.value === type.value);
           return (
-            <View key={ind}>
+            <View key={type.value} style={{ gap: Spacing.xs }}>
               <View
                 style={{
                   flexDirection: "row",
-                  gap: Spacing.xs,
-                  paddingLeft: Spacing.lg,
                   alignItems: "center",
+                  gap: Spacing.sm,
                 }}
               >
-                <Icon size={16} source={typeToIcon(type?.value)} />
-                <ThemedText>{type.label} elérhetőséged</ThemedText>
+                <View
+                  style={{
+                    width: 32,
+                    height: 32,
+                    borderRadius: BorderRadius.full,
+                    backgroundColor: theme.colors.surfaceVariant,
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <IconButton
+                    icon={typeToIcon(type?.value)}
+                    size={16}
+                    iconColor={theme.colors.primary}
+                    style={{ margin: 0 }}
+                  />
+                </View>
+                <ThemedText
+                  variant="bodyMedium"
+                  style={{ flex: 1, color: theme.colors.onSurfaceVariant }}
+                >
+                  {type.label}
+                </ThemedText>
+                {props.showFeaturedToggle &&
+                  filled &&
+                  typeof current.id === "number" && (
+                    <IconButton
+                      icon={isFeatured ? "star" : "star-outline"}
+                      size={20}
+                      iconColor={
+                        isFeatured
+                          ? theme.colors.primary
+                          : theme.colors.onSurfaceVariant
+                      }
+                      onPress={() => {
+                        if (typeof current.id === "number") {
+                          props.onDefaultContactChange?.(
+                            isFeatured ? undefined : current.id,
+                          );
+                        }
+                      }}
+                      accessibilityLabel={
+                        isFeatured
+                          ? "Kiemelt elérhetőség eltávolítása"
+                          : "Beállítás kiemelt elérhetőségként"
+                      }
+                    />
+                  )}
               </View>
               <TextInput
+                mode="outlined"
                 label={typeToValueLabel(type?.value)}
                 value={current?.data}
                 disabled={loading || !type.label}
                 left={typeToPrefix(type.value)}
                 placeholder={typeToPlaceholder(type.value)}
-                onChangeText={(t) => saveContact(ind, { data: t })}
+                onChangeText={(t) => saveContact(typeIndex, { data: t })}
                 error={error?.type === type.value}
               />
               {(!!current.data || !!current.title) && (
                 <TextInput
+                  mode="outlined"
                   value={current?.title || ""}
                   disabled={loading}
                   label="Egyéb információ"
                   placeholder="Munkanapokon keress / csak hétvégén"
-                  onChangeText={(t) => saveContact(ind, { title: t })}
+                  onChangeText={(t) => saveContact(typeIndex, { title: t })}
                 />
               )}
               {error?.type === type.value && (
-                <ThemedText type="error" style={{ marginLeft: Spacing.lg }}>
+                <ThemedText type="error" style={{ marginLeft: Spacing.xs }}>
                   {error?.text}
                 </ThemedText>
               )}
             </View>
           );
         })}
+      {!loading && hiddenTypes.length > 0 && (
+        <Menu
+          visible={addMenuVisible}
+          onDismiss={() => setAddMenuVisible(false)}
+          anchor={
+            <Button
+              icon="plus"
+              mode="text"
+              onPress={() => setAddMenuVisible(true)}
+              style={{ alignSelf: "flex-start" }}
+            >
+              Új elérhetőség
+            </Button>
+          }
+        >
+          {hiddenTypes.map((t) => (
+            <Menu.Item
+              key={t.value}
+              leadingIcon={typeToIcon(t.value)}
+              title={t.label}
+              onPress={() => {
+                setRevealedTypes((prev) => [...prev, t.value]);
+                setAddMenuVisible(false);
+              }}
+            />
+          ))}
+        </Menu>
+      )}
     </View>
   );
 });

--- a/components/buziness/SectionLabel.tsx
+++ b/components/buziness/SectionLabel.tsx
@@ -1,0 +1,46 @@
+import { View } from "react-native";
+import { Text } from "react-native-paper";
+import { Spacing } from "@/constants/spacing";
+import { useAppTheme } from "@/assets/theme";
+
+interface SectionLabelProps {
+  label: string;
+  optional?: boolean;
+  required?: boolean;
+}
+
+export default function SectionLabel({
+  label,
+  optional,
+  required,
+}: SectionLabelProps) {
+  const theme = useAppTheme();
+  return (
+    <View
+      style={{
+        flexDirection: "row",
+        alignItems: "baseline",
+        gap: Spacing.xs,
+        paddingLeft: Spacing.xs,
+      }}
+    >
+      <Text
+        variant="titleMedium"
+        style={{ color: theme.colors.onSurface, fontWeight: "600" }}
+      >
+        {label}
+        {required && (
+          <Text style={{ color: theme.colors.error }}> *</Text>
+        )}
+      </Text>
+      {optional && (
+        <Text
+          variant="bodySmall"
+          style={{ color: theme.colors.onSurfaceVariant }}
+        >
+          (nem kötelező)
+        </Text>
+      )}
+    </View>
+  );
+}

--- a/components/user/MyBuzinesses.tsx
+++ b/components/user/MyBuzinesses.tsx
@@ -5,9 +5,10 @@ import { Image } from "expo-image";
 import { router } from "expo-router";
 import { useEffect, useState } from "react";
 import { View } from "react-native";
-import { ActivityIndicator, FAB, Text } from "react-native-paper";
+import { ActivityIndicator, Button, Text } from "react-native-paper";
 import { useDispatch } from "react-redux";
 import BuzinessItem from "../buziness/BuzinessItem";
+import SectionLabel from "../buziness/SectionLabel";
 import { ThemedText } from "../ThemedText";
 import { ThemedView } from "../ThemedView";
 import { Spacing } from "@/constants/spacing";
@@ -55,16 +56,14 @@ const MyBuzinesses = ({ uid, myProfile, name }: MyBuzinessesProps) => {
       });
   }, [dispatch, uid]);
   return (
-    <View style={{ paddingHorizontal: Spacing.md, paddingVertical: Spacing.lg, gap: Spacing.md }}>
+    <View style={{ paddingHorizontal: Spacing.md, paddingBottom: Spacing.lg, gap: Spacing.md }}>
       {loading ? (
         <View style={{ padding: Spacing.xxxl, alignItems: "center" }}>
           <ActivityIndicator />
         </View>
       ) : buzinesses.length ? (
         <>
-          <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant, paddingLeft: Spacing.xs }}>
-            {myProfile ? "Bizniszeim" : `${name} bizniszei`}
-          </Text>
+          <SectionLabel label={myProfile ? "Bizniszeim" : `${name} bizniszei`} />
           {buzinesses.map((buzinessItem) => (
             <BuzinessItem
               data={buzinessItem}
@@ -72,14 +71,6 @@ const MyBuzinesses = ({ uid, myProfile, name }: MyBuzinessesProps) => {
               showOptions
             />
           ))}
-          {myProfile && (
-            <FAB
-              icon={"plus"}
-              label={"Új biznisz"}
-              style={{ alignSelf: "center", marginVertical: Spacing.lg, borderRadius: BorderRadius.pill }}
-              onPress={() => router.push("/biznisz/new")}
-            />
-          )}
         </>
       ) : (
         <View style={{ alignItems: "center", gap: Spacing.lg, padding: Spacing.sm }}>
@@ -94,12 +85,16 @@ const MyBuzinesses = ({ uid, myProfile, name }: MyBuzinessesProps) => {
                   ? "Itt fognak megjelenni a saját bizniszeid."
                   : `${name} még nem adott meg bizniszt.`}
               </ThemedText>
-              <FAB
-                icon={"plus"}
-                label={"Új biznisz"}
-                visible={myProfile}
-                onPress={() => router.push("/biznisz/new")}
-              />
+              {myProfile && (
+                <Button
+                  mode="contained"
+                  icon="plus"
+                  style={{ borderRadius: BorderRadius.pill }}
+                  onPress={() => router.push("/biznisz/new")}
+                >
+                  Új biznisz
+                </Button>
+              )}
             </View>
           </ThemedView>
           <Text>

--- a/components/user/UserPage.tsx
+++ b/components/user/UserPage.tsx
@@ -31,13 +31,14 @@ import { Linking, ScrollView, View } from "react-native";
 import {
   Badge,
   Button,
+  FAB,
   Icon,
   IconButton,
   Portal,
   Surface,
   Text,
   TouchableRipple,
-   
+
 } from "react-native-paper";
 import * as Clipboard from "expo-clipboard";
 
@@ -50,6 +51,7 @@ import {
   viewFunction,
 } from "@/redux/reducers/tutorialReducer";
 import Measure from "@/components/tutorial/Measure";
+import SectionLabel from "@/components/buziness/SectionLabel";
 import { useAppTheme } from "@/assets/theme";
 
 type UserInfo = Tables<"profiles">;
@@ -152,8 +154,8 @@ export default function UserPage() {
       {<Stack.Screen options={{ title:myProfile ? "Profilod" : "" }} />}
       <ThemedView style={{ flex: 1 }}>
         {data && uid && (
-          <ScrollView>
-            <ThemedView style={{ paddingHorizontal: Spacing.md, paddingTop: Spacing.xxl, paddingBottom: Spacing.lg, gap: Spacing.lg }}>
+          <ScrollView contentContainerStyle={{ paddingBottom: myProfile ? 96 : 0 }}>
+            <ThemedView style={{ paddingHorizontal: Spacing.md, paddingTop: Spacing.xxl, paddingBottom: Spacing.xl, gap: Spacing.xl }}>
               {/* Report button */}
               {!myProfile && (
                 <IconButton
@@ -270,9 +272,7 @@ export default function UserPage() {
               {/* Contacts */}
               {contacts.length > 0 && (
                 <View style={{ width: "100%", gap: Spacing.sm }}>
-                  <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant, paddingLeft: Spacing.xs }}>
-                    Elérhetőségek
-                  </Text>
+                  <SectionLabel label="Elérhetőségek" />
                   <Surface
                     style={{
                       borderRadius: BorderRadius.lg,
@@ -377,13 +377,24 @@ export default function UserPage() {
               </View>
             </ThemedView>
 
-            <View style={{ height: Spacing.sm, backgroundColor: theme.colors.background }} />
-
             {/* Businesses */}
             <Measure name="user-biznisz-tabs">
               <MyBuzinesses uid={uid} myProfile={myProfile} name={data.full_name ?? undefined} />
             </Measure>
           </ScrollView>
+        )}
+        {myProfile && (
+          <FAB
+            icon="plus"
+            label="Új biznisz"
+            onPress={() => router.push("/biznisz/new")}
+            style={{
+              position: "absolute",
+              right: Spacing.md,
+              bottom: Spacing.md,
+              borderRadius: BorderRadius.pill,
+            }}
+          />
         )}
       </ThemedView>
       {!!data?.full_name && (


### PR DESCRIPTION
## Summary
- Float the "Új biznisz" FAB over the profile (with a scroll padding so it never covers card actions) and unify profile section headers via a new `SectionLabel` component.
- Rework the new/edit biznisz screen as a focused full-bleed flow: hide the bottom nav on `/biznisz/new` and `/biznisz/edit`, redesign the tag input as chips, contacts as reveal-on-demand with a featured-star toggle, and image upload as a tile grid with an edit modal.

## Test plan
- [ ] Profile: FAB visible, action buttons on the last biznisz card not covered while scrolled to the bottom.
- [ ] `/biznisz/new`: bottom nav hidden, tag chips add/remove, contacts reveal via "+ Új elérhetőség", featured star toggles default contact, image tiles open edit modal with description + delete/restore.
- [ ] `/biznisz/edit/[id]`: existing data loads correctly into the new contact picker, tag chips, and image grid.
- [ ] Save → success path and validation errors (missing title/category/description/contact) still surface as snackbars.