### PR TITLE
Add web-only FiFe admin site with health tests and reports viewer

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -3,3 +3,4 @@ dist
 ios
 android
 node_modules
+app/admin

--- a/app/admin/_layout.tsx
+++ b/app/admin/_layout.tsx
@@ -1,0 +1,176 @@
+import React, { useEffect, useState } from 'react';
+import { Platform, View, Text, TextInput, Pressable, StyleSheet, ScrollView, ActivityIndicator } from 'react-native';
+import { Redirect, Slot, usePathname, Link } from 'expo-router';
+import { supabase } from '@/lib/supabase/supabase';
+import type { Session } from '@supabase/supabase-js';
+import { AdminContext } from './lib/context';
+
+const ADMIN_EMAILS = ['kristofakos1229@gmail.com'];
+
+const C = {
+  bg: '#0d1117',
+  surface: '#161b22',
+  border: '#30363d',
+  text: '#c9d1d9',
+  muted: '#8b949e',
+  accent: '#58a6ff',
+  success: '#3fb950',
+  error: '#f85149',
+};
+
+function getFromSession(key: string) {
+  try { return sessionStorage.getItem(key) ?? ''; } catch { return ''; }
+}
+function saveToSession(key: string, value: string) {
+  try { sessionStorage.setItem(key, value); } catch {}
+}
+
+function AdminLoginScreen() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleLogin() {
+    setLoading(true);
+    setError('');
+    const { error } = await supabase.auth.signInWithPassword({ email: email.trim(), password });
+    if (error) { setError(error.message); setLoading(false); return; }
+    window.location.reload();
+  }
+
+  return (
+    <View style={[styles.center, { backgroundColor: C.bg, flex: 1 }]}>
+      <View style={[styles.card, { width: 340 }]}>
+        <Text style={[styles.title, { marginBottom: 24 }]}>FiFe Admin</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Email"
+          placeholderTextColor={C.muted}
+          value={email}
+          onChangeText={setEmail}
+          keyboardType="email-address"
+          autoCapitalize="none"
+        />
+        <TextInput
+          style={[styles.input, { marginTop: 10 }]}
+          placeholder="Password"
+          placeholderTextColor={C.muted}
+          value={password}
+          onChangeText={setPassword}
+          secureTextEntry
+          onSubmitEditing={handleLogin}
+        />
+        {!!error && <Text style={{ color: C.error, marginTop: 8, fontSize: 13 }}>{error}</Text>}
+        <Pressable style={[styles.btn, { marginTop: 16 }]} onPress={handleLogin} disabled={loading}>
+          <Text style={styles.btnText}>{loading ? 'Signing in…' : 'Sign in'}</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+function AdminNav() {
+  const pathname = usePathname();
+  return (
+    <View style={styles.nav}>
+      <Text style={styles.navBrand}>⚡ FiFe Admin</Text>
+      <Text style={styles.navEnv} numberOfLines={1}>
+        {process.env.EXPO_PUBLIC_SUPABASE_URL}
+      </Text>
+      <View style={styles.navLinks}>
+        <Link href="/admin" style={[styles.navLink, pathname === '/admin' && styles.navLinkActive]}>
+          <Text style={{ color: pathname === '/admin' ? C.accent : C.muted, fontSize: 14 }}>Tests</Text>
+        </Link>
+        <Link href="/admin/reports" style={[styles.navLink, pathname === '/admin/reports' && styles.navLinkActive]}>
+          <Text style={{ color: pathname === '/admin/reports' ? C.accent : C.muted, fontSize: 14 }}>Reports</Text>
+        </Link>
+      </View>
+      <Pressable onPress={() => { supabase.auth.signOut().then(() => window.location.reload()); }}>
+        <Text style={{ color: C.muted, fontSize: 13 }}>Sign out</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export default function AdminLayout() {
+  if (Platform.OS !== 'web') return <Redirect href="/" />;
+
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [serviceRoleKey, setServiceRoleKeyState] = useState('');
+  const [testEmail, setTestEmailState] = useState('');
+  const [testPassword, setTestPasswordState] = useState('');
+
+  useEffect(() => {
+    setServiceRoleKeyState(getFromSession('admin_srk'));
+    setTestEmailState(getFromSession('admin_test_email'));
+    setTestPasswordState(getFromSession('admin_test_password'));
+    supabase.auth.getSession().then((res: { data: { session: Session | null } }) => {
+      setSession(res.data.session);
+      setLoading(false);
+    });
+  }, []);
+
+  const setServiceRoleKey = (key: string) => { setServiceRoleKeyState(key); saveToSession('admin_srk', key); };
+  const setTestEmail = (e: string) => { setTestEmailState(e); saveToSession('admin_test_email', e); };
+  const setTestPassword = (p: string) => { setTestPasswordState(p); saveToSession('admin_test_password', p); };
+
+  if (loading) return <View style={[styles.center, { flex: 1, backgroundColor: C.bg }]}><ActivityIndicator color={C.accent} /></View>;
+  if (!session || !ADMIN_EMAILS.includes(session.user.email ?? '')) return <AdminLoginScreen />;
+
+  return (
+    <AdminContext.Provider value={{ serviceRoleKey, testEmail, testPassword, setServiceRoleKey, setTestEmail, setTestPassword }}>
+      <View style={{ flex: 1, backgroundColor: C.bg }}>
+        <AdminNav />
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: 20 }}>
+          <Slot />
+        </ScrollView>
+      </View>
+    </AdminContext.Provider>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { alignItems: 'center', justifyContent: 'center' },
+  card: {
+    backgroundColor: C.surface,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: C.border,
+    padding: 24,
+  },
+  title: { color: C.text, fontSize: 22, fontWeight: '700' },
+  input: {
+    backgroundColor: C.bg,
+    borderWidth: 1,
+    borderColor: C.border,
+    borderRadius: 6,
+    color: C.text,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+  },
+  btn: {
+    backgroundColor: C.accent,
+    borderRadius: 6,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  btnText: { color: '#0d1117', fontWeight: '700', fontSize: 14 },
+  nav: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+    backgroundColor: C.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: C.border,
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+  },
+  navBrand: { color: C.text, fontSize: 16, fontWeight: '700', marginRight: 8 },
+  navEnv: { color: C.muted, fontSize: 11, flex: 1 },
+  navLinks: { flexDirection: 'row', gap: 4 },
+  navLink: { paddingHorizontal: 12, paddingVertical: 6, borderRadius: 6 },
+  navLinkActive: { backgroundColor: '#1c2742' },
+});

--- a/app/admin/index.tsx
+++ b/app/admin/index.tsx
@@ -1,0 +1,392 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View, Text, TextInput, Pressable, StyleSheet, ActivityIndicator,
+} from 'react-native';
+import { supabase } from '@/lib/supabase/supabase';
+import type { Session } from '@supabase/supabase-js';
+import { useAdmin } from './lib/context';
+import type { TestResult, TestStatus, TestResultMap } from './lib/types';
+import {
+  testBusinessSearch, testNearestProfiles,
+  testCreateBuzinessNoContact, testCreateBuzinessWithContact,
+  testRegistration, testLogin,
+  type BusinessSearchParams, type NearestProfilesParams,
+} from './lib/tests';
+
+const C = {
+  bg: '#0d1117', surface: '#161b22', border: '#30363d',
+  text: '#c9d1d9', muted: '#8b949e', accent: '#58a6ff',
+  success: '#3fb950', error: '#f85149', warning: '#d29922',
+};
+
+// ────────────────────────────────────────────────
+// Shared UI primitives
+// ────────────────────────────────────────────────
+
+function Badge({ status }: { status: TestStatus }) {
+  const map: Record<TestStatus, [string, string]> = {
+    idle:    ['#8b949e', '#161b22'],
+    running: ['#d29922', '#2a1f00'],
+    pass:    ['#3fb950', '#0d2617'],
+    fail:    ['#f85149', '#2a0a0a'],
+  };
+  const [color, bg] = map[status];
+  return (
+    <View style={{ backgroundColor: bg, borderRadius: 4, paddingHorizontal: 8, paddingVertical: 2 }}>
+      <Text style={{ color, fontSize: 12, fontWeight: '600' }}>{status.toUpperCase()}</Text>
+    </View>
+  );
+}
+
+function Field({ label, value, onChange, placeholder, secure }: {
+  label: string; value: string; onChange: (v: string) => void;
+  placeholder?: string; secure?: boolean;
+}) {
+  return (
+    <View style={{ marginBottom: 8 }}>
+      <Text style={styles.fieldLabel}>{label}</Text>
+      <TextInput
+        style={styles.input}
+        value={value}
+        onChangeText={onChange}
+        placeholder={placeholder}
+        placeholderTextColor={C.muted}
+        secureTextEntry={secure}
+        autoCapitalize="none"
+      />
+    </View>
+  );
+}
+
+function NumField({ label, value, onChange }: { label: string; value: number; onChange: (v: number) => void }) {
+  return (
+    <View style={styles.numField}>
+      <Text style={styles.fieldLabel}>{label}</Text>
+      <TextInput
+        style={[styles.input, { width: 120 }]}
+        value={String(value)}
+        onChangeText={(t: string) => { const n = parseFloat(t); if (!isNaN(n)) onChange(n); }}
+        placeholderTextColor={C.muted}
+        keyboardType="numeric"
+      />
+    </View>
+  );
+}
+
+function ResponsePanel({ response, error }: { response?: unknown; error?: string }) {
+  const text = error
+    ? `Error: ${error}`
+    : response !== undefined
+    ? JSON.stringify(response, null, 2)
+    : '';
+  if (!text) return null;
+  return (
+    <View style={styles.responsePanel}>
+      <Text style={{ color: error ? C.error : C.text, fontFamily: 'monospace', fontSize: 12, whiteSpace: 'pre-wrap' } as any}>
+        {text}
+      </Text>
+    </View>
+  );
+}
+
+// ────────────────────────────────────────────────
+// Business-search result renderer (shows embedding_text)
+// ────────────────────────────────────────────────
+
+function BusinessSearchResult({ result }: { result: TestResult }) {
+  if (result.status === 'idle' || result.status === 'running') return null;
+  if (result.status === 'fail') return <ResponsePanel error={result.error} response={result.response} />;
+
+  const resp = result.response as { embedding_text?: string; results?: unknown[] } | unknown[] | null;
+  const embeddingText = resp && !Array.isArray(resp) ? (resp as { embedding_text?: string }).embedding_text : undefined;
+  const results = resp && !Array.isArray(resp) ? (resp as { results?: unknown[] }).results : (resp as unknown[]);
+
+  return (
+    <View style={{ marginTop: 8, gap: 6 }}>
+      {!!embeddingText && (
+        <View style={[styles.responsePanel, { borderColor: '#2a3a1a' }]}>
+          <Text style={{ color: C.muted, fontSize: 11, marginBottom: 4 }}>EMBEDDING TEXT (AI expansion)</Text>
+          <Text style={{ color: '#3fb950', fontFamily: 'monospace', fontSize: 12 }}>{embeddingText}</Text>
+        </View>
+      )}
+      <View style={styles.responsePanel}>
+        <Text style={{ color: C.muted, fontSize: 11, marginBottom: 4 }}>RESULTS ({Array.isArray(results) ? results.length : 0})</Text>
+        <Text style={{ color: C.text, fontFamily: 'monospace', fontSize: 12, whiteSpace: 'pre-wrap' } as any}>
+          {JSON.stringify(results, null, 2)}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+// ────────────────────────────────────────────────
+// Test card
+// ────────────────────────────────────────────────
+
+function TestCard({
+  id, title, description, result, onRun, running,
+  children,
+}: {
+  id: string; title: string; description: string;
+  result: TestResult; onRun: () => void; running: boolean;
+  children?: React.ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    if (result.status === 'pass' || result.status === 'fail') setExpanded(true);
+  }, [result.status]);
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.cardHeader}>
+        <View style={{ flex: 1, gap: 3 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+            <Text style={styles.cardTitle}>{title}</Text>
+            <Badge status={result.status} />
+            {result.durationMs > 0 && (
+              <Text style={{ color: C.muted, fontSize: 12 }}>{result.durationMs}ms</Text>
+            )}
+          </View>
+          <Text style={styles.cardDesc}>{description}</Text>
+        </View>
+        <Pressable
+          style={[styles.runBtn, running && styles.runBtnDisabled]}
+          onPress={onRun}
+          disabled={running}
+        >
+          {running ? <ActivityIndicator color={C.accent} size="small" /> : <Text style={styles.runBtnText}>Run</Text>}
+        </Pressable>
+      </View>
+
+      {children && (
+        <View style={{ marginTop: 12, borderTopWidth: 1, borderTopColor: C.border, paddingTop: 12 }}>
+          {children}
+        </View>
+      )}
+
+      {(result.status === 'pass' || result.status === 'fail') && (
+        <Pressable
+          style={{ marginTop: 8 }}
+          onPress={() => setExpanded((v: boolean) => !v)}
+        >
+          <Text style={{ color: C.accent, fontSize: 12 }}>{expanded ? '▲ Hide response' : '▼ Show response'}</Text>
+        </Pressable>
+      )}
+
+      {expanded && id === 'business-search' && <BusinessSearchResult result={result} />}
+      {expanded && id !== 'business-search' && <ResponsePanel response={result.response} error={result.error} />}
+    </View>
+  );
+}
+
+// ────────────────────────────────────────────────
+// Setup panel
+// ────────────────────────────────────────────────
+
+function SetupPanel() {
+  const { serviceRoleKey, testEmail, testPassword, setServiceRoleKey, setTestEmail, setTestPassword } = useAdmin();
+  const [open, setOpen] = useState(!serviceRoleKey || !testEmail);
+
+  return (
+    <View style={[styles.card, { marginBottom: 20 }]}>
+      <Pressable onPress={() => setOpen((v: boolean) => !v)} style={styles.cardHeader}>
+        <Text style={styles.cardTitle}>⚙ Setup</Text>
+        <Text style={{ color: C.muted, fontSize: 12 }}>
+          {serviceRoleKey ? '✓ Service key set' : '⚠ Service key missing'} ·{' '}
+          {testEmail ? `Test: ${testEmail}` : '⚠ Test account missing'}
+        </Text>
+        <Text style={{ color: C.accent, fontSize: 13 }}>{open ? '▲' : '▼'}</Text>
+      </Pressable>
+      {open && (
+        <View style={{ marginTop: 12, borderTopWidth: 1, borderTopColor: C.border, paddingTop: 12, gap: 4 }}>
+          <Field label="Service Role Key" value={serviceRoleKey} onChange={setServiceRoleKey} placeholder="eyJhbGci..." secure />
+          <Field label="Test Account Email" value={testEmail} onChange={setTestEmail} placeholder="test@example.com" />
+          <Field label="Test Account Password" value={testPassword} onChange={setTestPassword} placeholder="••••••••" secure />
+          <Text style={{ color: C.muted, fontSize: 11, marginTop: 4 }}>
+            Stored in sessionStorage only — cleared when you close the tab.
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+// ────────────────────────────────────────────────
+// Main dashboard
+// ────────────────────────────────────────────────
+
+const DEFAULT_RESULTS: TestResultMap = {
+  'business-search': { status: 'idle', durationMs: 0 },
+  'nearest-profiles': { status: 'idle', durationMs: 0 },
+  'create-buziness-no-contact': { status: 'idle', durationMs: 0 },
+  'create-buziness-with-contact': { status: 'idle', durationMs: 0 },
+  'registration': { status: 'idle', durationMs: 0 },
+  'login': { status: 'idle', durationMs: 0 },
+};
+
+export default function AdminTestDashboard() {
+  const { serviceRoleKey, testEmail, testPassword } = useAdmin();
+  const [session, setSession] = useState<Session | null>(null);
+  const [results, setResults] = useState<TestResultMap>(DEFAULT_RESULTS);
+  const [running, setRunning] = useState<Record<string, boolean>>({});
+  const [runningAll, setRunningAll] = useState(false);
+
+  // business-search params
+  const [bsParams, setBsParams] = useState<BusinessSearchParams>({ query: 'kávé', lat: 47.4979, long: 19.0402, take: 5, matchThreshold: 0.5 });
+  // nearest_profiles params
+  const [npParams, setNpParams] = useState<NearestProfilesParams>({ lat: 47.4979, long: 19.0402, distance: 50000, take: 6 });
+
+  useEffect(() => {
+    supabase.auth.getSession().then((res: { data: { session: Session | null } }) => setSession(res.data.session));
+  }, []);
+
+  function setResult(id: string, result: TestResult) {
+    setResults((prev: TestResultMap) => ({ ...prev, [id]: result }));
+  }
+
+  function setRunningState(id: string, value: boolean) {
+    setRunning((prev: Record<string, boolean>) => ({ ...prev, [id]: value }));
+  }
+
+  const runTest = useCallback(async (id: string) => {
+    if (running[id]) return;
+    setRunningState(id, true);
+    setResult(id, { status: 'running', durationMs: 0 });
+    let result: TestResult;
+
+    try {
+      switch (id) {
+        case 'business-search':
+          if (!session) throw new Error('Not logged in');
+          result = await testBusinessSearch(session, bsParams);
+          break;
+        case 'nearest-profiles':
+          result = await testNearestProfiles(supabase, npParams);
+          break;
+        case 'create-buziness-no-contact':
+          if (!testEmail || !testPassword) throw new Error('Test account credentials required');
+          result = await testCreateBuzinessNoContact(testEmail, testPassword);
+          break;
+        case 'create-buziness-with-contact':
+          if (!testEmail || !testPassword) throw new Error('Test account credentials required');
+          if (!serviceRoleKey) throw new Error('Service role key required');
+          result = await testCreateBuzinessWithContact(testEmail, testPassword, serviceRoleKey);
+          break;
+        case 'registration':
+          if (!serviceRoleKey) throw new Error('Service role key required');
+          result = await testRegistration(serviceRoleKey);
+          break;
+        case 'login':
+          if (!testEmail || !testPassword) throw new Error('Test account credentials required');
+          result = await testLogin(testEmail, testPassword);
+          break;
+        default:
+          result = { status: 'fail', durationMs: 0, error: `Unknown test: ${id}` };
+      }
+    } catch (e: unknown) {
+      result = { status: 'fail', durationMs: 0, error: (e as Error)?.message ?? String(e) };
+    }
+
+    setResult(id, result);
+    setRunningState(id, false);
+  }, [session, serviceRoleKey, testEmail, testPassword, bsParams, npParams, running]);
+
+  async function runAll() {
+    setRunningAll(true);
+    const ids = Object.keys(DEFAULT_RESULTS);
+    for (const id of ids) await runTest(id);
+    setRunningAll(false);
+  }
+
+  const anyRunning = runningAll || Object.values(running).some(Boolean);
+
+  return (
+    <View>
+      <SetupPanel />
+
+      <View style={styles.pageHeader}>
+        <Text style={styles.pageTitle}>Health Tests</Text>
+        <Pressable style={[styles.runAllBtn, anyRunning && styles.runBtnDisabled]} onPress={runAll} disabled={anyRunning}>
+          {anyRunning
+            ? <><ActivityIndicator color="#0d1117" size="small" style={{ marginRight: 6 }} /><Text style={styles.runAllBtnText}>Running…</Text></>
+            : <Text style={styles.runAllBtnText}>▶ Run All</Text>
+          }
+        </Pressable>
+      </View>
+
+      {/* business-search */}
+      <TestCard id="business-search" title="business-search" description="Hybrid semantic + distance search edge function" result={results['business-search']} onRun={() => runTest('business-search')} running={!!running['business-search']}>
+        <View style={{ gap: 8 }}>
+          <Field label="Query" value={bsParams.query ?? ''} onChange={(v: string) => setBsParams((p: BusinessSearchParams) => ({ ...p, query: v }))} placeholder="kávé, fodrász…" />
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 12 }}>
+            <NumField label="Lat" value={bsParams.lat ?? 47.4979} onChange={(v: number) => setBsParams((p: BusinessSearchParams) => ({ ...p, lat: v }))} />
+            <NumField label="Long" value={bsParams.long ?? 19.0402} onChange={(v: number) => setBsParams((p: BusinessSearchParams) => ({ ...p, long: v }))} />
+            <NumField label="Take" value={bsParams.take ?? 5} onChange={(v: number) => setBsParams((p: BusinessSearchParams) => ({ ...p, take: v }))} />
+            <NumField label="Match threshold" value={bsParams.matchThreshold ?? 0.5} onChange={(v: number) => setBsParams((p: BusinessSearchParams) => ({ ...p, matchThreshold: v }))} />
+          </View>
+          <Text style={{ color: C.muted, fontSize: 11 }}>Edge cases: empty query = browse mode · threshold 0.99 = near-zero results</Text>
+        </View>
+      </TestCard>
+
+      {/* nearest_profiles */}
+      <TestCard id="nearest-profiles" title="nearest_profiles" description="DB RPC: PostGIS distance-ordered profiles" result={results['nearest-profiles']} onRun={() => runTest('nearest-profiles')} running={!!running['nearest-profiles']}>
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 12 }}>
+          <NumField label="Lat" value={npParams.lat ?? 47.4979} onChange={(v: number) => setNpParams((p: NearestProfilesParams) => ({ ...p, lat: v }))} />
+          <NumField label="Long" value={npParams.long ?? 19.0402} onChange={(v: number) => setNpParams((p: NearestProfilesParams) => ({ ...p, long: v }))} />
+          <NumField label="Distance (m)" value={npParams.distance ?? 50000} onChange={(v: number) => setNpParams((p: NearestProfilesParams) => ({ ...p, distance: v }))} />
+          <NumField label="Take" value={npParams.take ?? 6} onChange={(v: number) => setNpParams((p: NearestProfilesParams) => ({ ...p, take: v }))} />
+        </View>
+        <Text style={{ color: C.muted, fontSize: 11, marginTop: 4 }}>Edge cases: distance=1 → empty · distance=999999 → many results</Text>
+      </TestCard>
+
+      {/* create-buziness no contact */}
+      <TestCard id="create-buziness-no-contact" title="create-buziness (no contact)" description="Expects HTTP 400 — user has no contacts" result={results['create-buziness-no-contact']} onRun={() => runTest('create-buziness-no-contact')} running={!!running['create-buziness-no-contact']} />
+
+      {/* create-buziness with contact */}
+      <TestCard id="create-buziness-with-contact" title="create-buziness (with contact)" description="Adds temp contact → creates buziness → cleans up. Expects 200." result={results['create-buziness-with-contact']} onRun={() => runTest('create-buziness-with-contact')} running={!!running['create-buziness-with-contact']} />
+
+      {/* registration */}
+      <TestCard id="registration" title="registration" description="signUp with temp email, then deletes the user" result={results['registration']} onRun={() => runTest('registration')} running={!!running['registration']} />
+
+      {/* login */}
+      <TestCard id="login" title="login" description="signInWithPassword with test account" result={results['login']} onRun={() => runTest('login')} running={!!running['login']} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  pageHeader: { flexDirection: 'row', alignItems: 'center', marginBottom: 16 },
+  pageTitle: { color: C.text, fontSize: 18, fontWeight: '700', flex: 1 },
+  runAllBtn: {
+    flexDirection: 'row', alignItems: 'center',
+    backgroundColor: C.accent, borderRadius: 6,
+    paddingHorizontal: 16, paddingVertical: 8,
+  },
+  runAllBtnText: { color: '#0d1117', fontWeight: '700', fontSize: 14 },
+  card: {
+    backgroundColor: C.surface, borderRadius: 10,
+    borderWidth: 1, borderColor: C.border,
+    padding: 16, marginBottom: 12,
+  },
+  cardHeader: { flexDirection: 'row', alignItems: 'flex-start', gap: 12 },
+  cardTitle: { color: C.text, fontSize: 15, fontWeight: '600' },
+  cardDesc: { color: C.muted, fontSize: 12 },
+  runBtn: {
+    backgroundColor: '#21262d', borderRadius: 6, borderWidth: 1, borderColor: C.border,
+    paddingHorizontal: 14, paddingVertical: 6, minWidth: 60, alignItems: 'center',
+  },
+  runBtnDisabled: { opacity: 0.5 },
+  runBtnText: { color: C.text, fontSize: 13, fontWeight: '600' },
+  fieldLabel: { color: C.muted, fontSize: 11, marginBottom: 4, fontWeight: '600' },
+  input: {
+    backgroundColor: C.bg, borderWidth: 1, borderColor: C.border,
+    borderRadius: 6, color: C.text, paddingHorizontal: 10, paddingVertical: 7, fontSize: 13,
+  },
+  numField: { gap: 4 },
+  responsePanel: {
+    backgroundColor: '#0a0f17', borderRadius: 6, borderWidth: 1,
+    borderColor: C.border, padding: 12, marginTop: 6,
+    maxHeight: 400, overflow: 'scroll' as any,
+  },
+});

--- a/app/admin/lib/adminClient.ts
+++ b/app/admin/lib/adminClient.ts
@@ -1,0 +1,18 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from '@/database.types';
+
+export function createAdminClient(serviceRoleKey: string) {
+  return createClient<Database>(
+    process.env.EXPO_PUBLIC_SUPABASE_URL!,
+    serviceRoleKey,
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+}
+
+export function createFreshAnonClient() {
+  return createClient<Database>(
+    process.env.EXPO_PUBLIC_SUPABASE_URL!,
+    process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY!,
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+}

--- a/app/admin/lib/context.ts
+++ b/app/admin/lib/context.ts
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react';
+
+export interface AdminContextValue {
+  serviceRoleKey: string;
+  testEmail: string;
+  testPassword: string;
+  setServiceRoleKey: (key: string) => void;
+  setTestEmail: (email: string) => void;
+  setTestPassword: (pass: string) => void;
+}
+
+export const AdminContext = createContext<AdminContextValue>({
+  serviceRoleKey: '',
+  testEmail: '',
+  testPassword: '',
+  setServiceRoleKey: () => {},
+  setTestEmail: () => {},
+  setTestPassword: () => {},
+});
+
+export function useAdmin() {
+  return useContext(AdminContext);
+}

--- a/app/admin/lib/tests.ts
+++ b/app/admin/lib/tests.ts
@@ -1,0 +1,246 @@
+import type { SupabaseClient, Session } from '@supabase/supabase-js';
+import { createAdminClient, createFreshAnonClient } from './adminClient';
+import type { TestResult } from './types';
+
+const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL!;
+const DEFAULT_LAT = 47.4979;
+const DEFAULT_LONG = 19.0402;
+
+function timed<T>(fn: () => Promise<T>) {
+  const start = Date.now();
+  return fn().then(
+    (data) => ({ ok: true as const, data, durationMs: Date.now() - start }),
+    (err) => ({ ok: false as const, error: String(err?.message ?? err), durationMs: Date.now() - start }),
+  );
+}
+
+// ────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────
+
+async function loginTestClient(email: string, password: string) {
+  const client = createFreshAnonClient();
+  const { data, error } = await client.auth.signInWithPassword({ email, password });
+  if (error || !data.session) throw new Error(`Test account login failed: ${error?.message ?? 'no session'}`);
+  return { client, session: data.session };
+}
+
+// ────────────────────────────────────────────────
+// TEST 1: business-search (interactive)
+// ────────────────────────────────────────────────
+
+export interface BusinessSearchParams {
+  query: string;
+  lat?: number;
+  long?: number;
+  take?: number;
+  matchThreshold?: number;
+}
+
+export async function testBusinessSearch(
+  session: Session,
+  params: BusinessSearchParams,
+): Promise<TestResult> {
+  const result = await timed(async () => {
+    const res = await fetch(`${SUPABASE_URL}/functions/v1/business-search`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${session.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: params.query,
+        lat: params.lat ?? DEFAULT_LAT,
+        long: params.long ?? DEFAULT_LONG,
+        take: params.take ?? 5,
+        match_threshold: params.matchThreshold ?? 0.5,
+        debug: true,
+      }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
+    return data;
+  });
+  if (!result.ok) return { status: 'fail', durationMs: result.durationMs, error: result.error };
+  const results = result.data?.results ?? result.data;
+  if (!Array.isArray(results)) return { status: 'fail', durationMs: result.durationMs, error: 'Expected array in response', response: result.data };
+  return { status: 'pass', durationMs: result.durationMs, response: result.data };
+}
+
+// ────────────────────────────────────────────────
+// TEST 2: nearest_profiles (interactive)
+// ────────────────────────────────────────────────
+
+export interface NearestProfilesParams {
+  lat?: number;
+  long?: number;
+  distance?: number;
+  take?: number;
+}
+
+export async function testNearestProfiles(
+  supabase: SupabaseClient,
+  params: NearestProfilesParams,
+): Promise<TestResult> {
+  const result = await timed(() =>
+    supabase.rpc('nearest_profiles', {
+      lat: params.lat ?? DEFAULT_LAT,
+      long: params.long ?? DEFAULT_LONG,
+      distance: params.distance ?? 50000,
+      take: params.take ?? 6,
+      skip: 0,
+    }),
+  );
+  if (!result.ok) return { status: 'fail', durationMs: result.durationMs, error: result.error };
+  const { data, error } = result.data as { data: unknown; error: unknown };
+  if (error) {
+    const msg = (error as { message?: string })?.message ?? String(error);
+    return { status: 'fail', durationMs: result.durationMs, error: msg };
+  }
+  return { status: 'pass', durationMs: result.durationMs, response: data };
+}
+
+// ────────────────────────────────────────────────
+// TEST 3a: create-buziness WITHOUT contact → expects 400
+// ────────────────────────────────────────────────
+
+export async function testCreateBuzinessNoContact(
+  testEmail: string,
+  testPassword: string,
+): Promise<TestResult> {
+  let client: ReturnType<typeof createFreshAnonClient> | null = null;
+  const start = Date.now();
+  try {
+    const auth = await loginTestClient(testEmail, testPassword);
+    client = auth.client;
+
+    // Pre-cleanup: ensure no stale contacts exist for this test user
+    const adminKey = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('admin_srk') : null;
+    if (adminKey) {
+      const adminClient = createAdminClient(adminKey);
+      await adminClient.from('contacts').delete().eq('author', auth.session.user.id).eq('data', '+36000000000');
+    }
+
+    const res = await fetch(`${SUPABASE_URL}/functions/v1/create-buziness`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${auth.session.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ title: '__ADMIN_HEALTH_NO_CONTACT__', author: auth.session.user.id }),
+    });
+    const data = await res.json();
+    const durationMs = Date.now() - start;
+    if (res.status === 400 && typeof data.error === 'string' && data.error.toLowerCase().includes('contact')) {
+      return { status: 'pass', durationMs, response: data };
+    }
+    return { status: 'fail', durationMs, error: `Expected 400 with contact error, got ${res.status}: ${data.error ?? JSON.stringify(data)}`, response: data };
+  } catch (e: unknown) {
+    return { status: 'fail', durationMs: Date.now() - start, error: (e as Error)?.message ?? String(e) };
+  } finally {
+    await client?.auth.signOut().catch(() => {});
+  }
+}
+
+// ────────────────────────────────────────────────
+// TEST 3b: create-buziness WITH contact → expects 200, cleans up
+// ────────────────────────────────────────────────
+
+export async function testCreateBuzinessWithContact(
+  testEmail: string,
+  testPassword: string,
+  serviceRoleKey: string,
+): Promise<TestResult> {
+  const adminClient = createAdminClient(serviceRoleKey);
+  let client: ReturnType<typeof createFreshAnonClient> | null = null;
+  let contactId: number | null = null;
+  let buzinessId: number | null = null;
+  const start = Date.now();
+
+  try {
+    const auth = await loginTestClient(testEmail, testPassword);
+    client = auth.client;
+
+    // Pre-cleanup: remove any leftover test data
+    await adminClient.from('buziness').delete().eq('author', auth.session.user.id).like('title', '__ADMIN_HEALTH_%');
+
+    // Setup: add temp contact
+    const { data: contact, error: contactErr } = await adminClient
+      .from('contacts')
+      .insert({ author: auth.session.user.id, type: 'TEL', data: '+36000000000' })
+      .select()
+      .single();
+    if (contactErr || !contact) throw new Error(`Setup failed: ${contactErr?.message}`);
+    contactId = contact.id;
+
+    // Call create-buziness
+    const res = await fetch(`${SUPABASE_URL}/functions/v1/create-buziness`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${auth.session.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        title: '__ADMIN_HEALTH_CHECK__',
+        author: auth.session.user.id,
+        description: 'Admin health check — safe to delete',
+      }),
+    });
+    const data = await res.json();
+    buzinessId = data?.id ?? null;
+    const durationMs = Date.now() - start;
+
+    if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
+    return { status: 'pass', durationMs, response: data };
+  } catch (e: unknown) {
+    return { status: 'fail', durationMs: Date.now() - start, error: (e as Error)?.message ?? String(e) };
+  } finally {
+    if (buzinessId) await adminClient.from('buziness').delete().eq('id', buzinessId).then(() => {});
+    if (contactId) await adminClient.from('contacts').delete().eq('id', contactId).then(() => {});
+    await client?.auth.signOut().catch(() => {});
+  }
+}
+
+// ────────────────────────────────────────────────
+// TEST 4: registration → creates temp user, cleans up
+// ────────────────────────────────────────────────
+
+export async function testRegistration(serviceRoleKey: string): Promise<TestResult> {
+  const anonClient = createFreshAnonClient();
+  const adminClient = createAdminClient(serviceRoleKey);
+  const tempEmail = `test+health_${Date.now()}@fifeapp.test`;
+  let userId: string | null = null;
+  const start = Date.now();
+
+  try {
+    const { data, error } = await anonClient.auth.signUp({ email: tempEmail, password: 'TestPass1234!' });
+    const durationMs = Date.now() - start;
+    if (error) return { status: 'fail', durationMs, error: error.message };
+    userId = data.user?.id ?? null;
+    return { status: 'pass', durationMs, response: { userId, email: tempEmail } };
+  } catch (e: unknown) {
+    return { status: 'fail', durationMs: Date.now() - start, error: (e as Error)?.message ?? String(e) };
+  } finally {
+    if (userId) await adminClient.auth.admin.deleteUser(userId).catch(() => {});
+  }
+}
+
+// ────────────────────────────────────────────────
+// TEST 5: login
+// ────────────────────────────────────────────────
+
+export async function testLogin(testEmail: string, testPassword: string): Promise<TestResult> {
+  const client = createFreshAnonClient();
+  const start = Date.now();
+  try {
+    const { data, error } = await client.auth.signInWithPassword({ email: testEmail, password: testPassword });
+    const durationMs = Date.now() - start;
+    if (error) return { status: 'fail', durationMs, error: error.message };
+    if (!data.session) return { status: 'fail', durationMs, error: 'No session returned' };
+    return { status: 'pass', durationMs, response: { email: data.session.user.email } };
+  } catch (e: unknown) {
+    return { status: 'fail', durationMs: Date.now() - start, error: (e as Error)?.message ?? String(e) };
+  } finally {
+    await client.auth.signOut().catch(() => {});
+  }
+}

--- a/app/admin/lib/types.ts
+++ b/app/admin/lib/types.ts
@@ -1,0 +1,10 @@
+export type TestStatus = 'idle' | 'running' | 'pass' | 'fail';
+
+export interface TestResult {
+  status: TestStatus;
+  durationMs: number;
+  error?: string;
+  response?: unknown;
+}
+
+export type TestResultMap = Record<string, TestResult>;

--- a/app/admin/reports.tsx
+++ b/app/admin/reports.tsx
@@ -1,0 +1,206 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Pressable, StyleSheet, ActivityIndicator, TextInput } from 'react-native';
+import { createAdminClient } from './lib/adminClient';
+import { useAdmin } from './lib/context';
+
+const C = {
+  bg: '#0d1117', surface: '#161b22', border: '#30363d',
+  text: '#c9d1d9', muted: '#8b949e', accent: '#58a6ff',
+  success: '#3fb950', error: '#f85149', warning: '#d29922',
+};
+
+const PAGE_SIZE = 25;
+
+const REASON_LABELS: Record<string, string> = {
+  terms_violation: 'Terms violation',
+  not_trustworthy: 'Not trustworthy',
+  illegal_activity: 'Illegal activity',
+  other: 'Other',
+};
+
+interface Report {
+  id: number;
+  created_at: string;
+  reason: string;
+  description: string;
+  author: string;
+  reported_profile_id: string;
+  author_profile: { full_name: string | null; username: string | null } | null;
+  reported_profile: { full_name: string | null; username: string | null } | null;
+}
+
+export default function ReportsScreen() {
+  const { serviceRoleKey, setServiceRoleKey } = useAdmin();
+  const [reports, setReports] = useState<Report[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [keyInput, setKeyInput] = useState(serviceRoleKey);
+
+  async function fetchReports(srk: string, p: number) {
+    setLoading(true);
+    setError('');
+    try {
+      const admin = createAdminClient(srk);
+      const from = p * PAGE_SIZE;
+      const to = from + PAGE_SIZE - 1;
+
+      const { data, error: dbErr, count } = await admin
+        .from('reports')
+        .select(
+          `id, created_at, reason, description, author, reported_profile_id,
+           author_profile:profiles!reports_author_fkey(full_name, username),
+           reported_profile:profiles!reports_reported_profile_id_fkey(full_name, username)`,
+          { count: 'exact' },
+        )
+        .order('created_at', { ascending: false })
+        .range(from, to);
+
+      if (dbErr) { setError(dbErr.message); return; }
+      setReports((data ?? []) as Report[]);
+      setTotal(count ?? 0);
+    } catch (e: unknown) {
+      setError((e as Error)?.message ?? String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function load() {
+    if (!keyInput.trim()) { setError('Service role key required'); return; }
+    setServiceRoleKey(keyInput.trim());
+    fetchReports(keyInput.trim(), page);
+  }
+
+  useEffect(() => {
+    if (serviceRoleKey) fetchReports(serviceRoleKey, page);
+  }, [page]);
+
+  function profileLabel(p: { full_name: string | null; username: string | null } | null, id: string) {
+    if (!p) return id.slice(0, 8) + '…';
+    return p.full_name || p.username || id.slice(0, 8) + '…';
+  }
+
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  return (
+    <View>
+      <View style={styles.pageHeader}>
+        <Text style={styles.pageTitle}>Reports</Text>
+        {total > 0 && <Text style={{ color: C.muted, fontSize: 13 }}>{total} total</Text>}
+      </View>
+
+      {!serviceRoleKey && (
+        <View style={[styles.card, { marginBottom: 16 }]}>
+          <Text style={styles.fieldLabel}>Service Role Key required to bypass RLS</Text>
+          <TextInput
+            style={[styles.input, { marginBottom: 10 }]}
+            value={keyInput}
+            onChangeText={setKeyInput}
+            placeholder="eyJhbGci…"
+            placeholderTextColor={C.muted}
+            secureTextEntry
+            autoCapitalize="none"
+          />
+          <Pressable style={styles.btn} onPress={load}>
+            <Text style={styles.btnText}>Load reports</Text>
+          </Pressable>
+        </View>
+      )}
+
+      {!!error && (
+        <View style={[styles.card, { borderColor: C.error, marginBottom: 12 }]}>
+          <Text style={{ color: C.error, fontSize: 13 }}>{error}</Text>
+        </View>
+      )}
+
+      {loading && <ActivityIndicator color={C.accent} style={{ marginTop: 40 }} />}
+
+      {!loading && reports.length === 0 && serviceRoleKey && !error && (
+        <Text style={{ color: C.muted, textAlign: 'center', marginTop: 40 }}>No reports found.</Text>
+      )}
+
+      {!loading && reports.length > 0 && (
+        <>
+          <View style={styles.table}>
+            {/* Header */}
+            <View style={[styles.row, styles.headerRow]}>
+              <Text style={[styles.cell, styles.colId, styles.headerText]}>#</Text>
+              <Text style={[styles.cell, styles.colProfile, styles.headerText]}>Reporter</Text>
+              <Text style={[styles.cell, styles.colProfile, styles.headerText]}>Reported</Text>
+              <Text style={[styles.cell, styles.colReason, styles.headerText]}>Reason</Text>
+              <Text style={[styles.cell, styles.colDesc, styles.headerText]}>Description</Text>
+              <Text style={[styles.cell, styles.colDate, styles.headerText]}>Date</Text>
+            </View>
+
+            {reports.map((r: Report, i: number) => (
+              <View key={r.id} style={[styles.row, i % 2 === 1 && styles.rowAlt]}>
+                <Text style={[styles.cell, styles.colId, { color: C.muted }]}>{r.id}</Text>
+                <Text style={[styles.cell, styles.colProfile]}>{profileLabel(r.author_profile, r.author)}</Text>
+                <Text style={[styles.cell, styles.colProfile]}>{profileLabel(r.reported_profile, r.reported_profile_id)}</Text>
+                <View style={[styles.cell, styles.colReason]}>
+                  <View style={styles.reasonBadge}>
+                    <Text style={{ color: C.warning, fontSize: 11, fontWeight: '600' }}>
+                      {REASON_LABELS[r.reason] ?? r.reason}
+                    </Text>
+                  </View>
+                </View>
+                <Text style={[styles.cell, styles.colDesc]} numberOfLines={3}>{r.description}</Text>
+                <Text style={[styles.cell, styles.colDate, { color: C.muted }]}>
+                  {new Date(r.created_at).toLocaleDateString('hu-HU')}
+                </Text>
+              </View>
+            ))}
+          </View>
+
+          {totalPages > 1 && (
+            <View style={styles.pagination}>
+              <Pressable
+                style={[styles.pageBtn, page === 0 && { opacity: 0.3 }]}
+                onPress={() => setPage((p: number) => Math.max(0, p - 1))}
+                disabled={page === 0}
+              >
+                <Text style={{ color: C.text }}>← Prev</Text>
+              </Pressable>
+              <Text style={{ color: C.muted, fontSize: 13 }}>
+                Page {page + 1} / {totalPages}
+              </Text>
+              <Pressable
+                style={[styles.pageBtn, page >= totalPages - 1 && { opacity: 0.3 }]}
+                onPress={() => setPage((p: number) => Math.min(totalPages - 1, p + 1))}
+                disabled={page >= totalPages - 1}
+              >
+                <Text style={{ color: C.text }}>Next →</Text>
+              </Pressable>
+            </View>
+          )}
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  pageHeader: { flexDirection: 'row', alignItems: 'center', marginBottom: 16 },
+  pageTitle: { color: C.text, fontSize: 18, fontWeight: '700', flex: 1 },
+  card: { backgroundColor: C.surface, borderRadius: 10, borderWidth: 1, borderColor: C.border, padding: 16, marginBottom: 12 },
+  fieldLabel: { color: C.muted, fontSize: 11, marginBottom: 4, fontWeight: '600' },
+  input: { backgroundColor: C.bg, borderWidth: 1, borderColor: C.border, borderRadius: 6, color: C.text, paddingHorizontal: 10, paddingVertical: 7, fontSize: 13 },
+  btn: { backgroundColor: C.accent, borderRadius: 6, paddingVertical: 8, alignItems: 'center' },
+  btnText: { color: '#0d1117', fontWeight: '700', fontSize: 14 },
+  table: { backgroundColor: C.surface, borderRadius: 10, borderWidth: 1, borderColor: C.border, overflow: 'hidden' },
+  row: { flexDirection: 'row', alignItems: 'flex-start', borderBottomWidth: 1, borderBottomColor: C.border },
+  rowAlt: { backgroundColor: '#0d1117' },
+  headerRow: { backgroundColor: '#161b22', borderBottomWidth: 2, borderBottomColor: C.border },
+  cell: { color: C.text, fontSize: 13, padding: 10, lineHeight: 18 },
+  headerText: { color: C.muted, fontSize: 11, fontWeight: '700', textTransform: 'uppercase' },
+  colId: { width: 50 },
+  colProfile: { width: 130 },
+  colReason: { width: 140, justifyContent: 'center' },
+  colDesc: { flex: 1 },
+  colDate: { width: 90 },
+  reasonBadge: { backgroundColor: '#2a1f00', borderRadius: 4, paddingHorizontal: 6, paddingVertical: 2 },
+  pagination: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 24, marginTop: 16, marginBottom: 8 },
+  pageBtn: { backgroundColor: C.surface, borderWidth: 1, borderColor: C.border, borderRadius: 6, paddingHorizontal: 14, paddingVertical: 7 },
+});

--- a/supabase/functions/admin-health/index.ts
+++ b/supabase/functions/admin-health/index.ts
@@ -1,0 +1,134 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL") || "http://supabase-kong:8000";
+const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "";
+const adminSecret = Deno.env.get("ADMIN_HEALTH_SECRET") || "";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-admin-secret",
+};
+
+interface TestResult {
+  name: string;
+  status: "pass" | "fail";
+  durationMs: number;
+  error?: string;
+}
+
+function timed<T>(fn: () => Promise<T>): Promise<{ ok: boolean; data?: T; error?: string; durationMs: number }> {
+  const start = Date.now();
+  return fn().then(
+    (data) => ({ ok: true, data, durationMs: Date.now() - start }),
+    (err) => ({ ok: false, error: String(err?.message ?? err), durationMs: Date.now() - start }),
+  );
+}
+
+async function checkBusinessSearch(anonToken: string): Promise<TestResult> {
+  const result = await timed(async () => {
+    const res = await fetch(`${supabaseUrl}/functions/v1/business-search`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${anonToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "kávé", lat: 47.4979, long: 19.0402, take: 3 }),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    if (!Array.isArray(data) && !Array.isArray(data?.results)) throw new Error("Expected array response");
+  });
+  return { name: "business-search", status: result.ok ? "pass" : "fail", durationMs: result.durationMs, error: result.error };
+}
+
+async function checkNearestProfiles(anonToken: string): Promise<TestResult> {
+  const supabase = createClient(supabaseUrl, Deno.env.get("SUPABASE_ANON_KEY") || "", {
+    global: { headers: { Authorization: `Bearer ${anonToken}` } },
+  });
+  const result = await timed(async () => {
+    const { data, error } = await supabase.rpc("nearest_profiles", { lat: 47.4979, long: 19.0402, distance: 50000, take: 3, skip: 0 });
+    if (error) throw new Error(error.message);
+    if (!Array.isArray(data)) throw new Error("Expected array");
+  });
+  return { name: "nearest_profiles", status: result.ok ? "pass" : "fail", durationMs: result.durationMs, error: result.error };
+}
+
+async function checkCreateBuziness(anonToken: string, userId: string): Promise<TestResult> {
+  const admin = createClient(supabaseUrl, serviceRoleKey);
+  let contactId: number | null = null;
+  let buzinessId: number | null = null;
+
+  const result = await timed(async () => {
+    // Setup contact
+    const { data: contact, error: ce } = await admin
+      .from("contacts")
+      .insert({ author: userId, type: "TEL", data: "+36000000000" })
+      .select()
+      .single();
+    if (ce || !contact) throw new Error(`Contact setup: ${ce?.message}`);
+    contactId = contact.id;
+
+    const res = await fetch(`${supabaseUrl}/functions/v1/create-buziness`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${anonToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "__ADMIN_HEALTH_CHECK__", author: userId }),
+    });
+    const data = await res.json();
+    buzinessId = data?.id ?? null;
+    if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
+  });
+
+  // Cleanup
+  if (buzinessId) await admin.from("buziness").delete().eq("id", buzinessId);
+  if (contactId) await admin.from("contacts").delete().eq("id", contactId);
+
+  return { name: "create-buziness", status: result.ok ? "pass" : "fail", durationMs: result.durationMs, error: result.error };
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+
+  const secret = req.headers.get("x-admin-secret");
+  if (adminSecret && secret !== adminSecret) {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 403,
+    });
+  }
+
+  // Need a test user token to call authenticated functions
+  const { test_email, test_password } = await req.json().catch(() => ({})) as { test_email?: string; test_password?: string };
+  if (!test_email || !test_password) {
+    return new Response(JSON.stringify({ error: "test_email and test_password required" }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 400,
+    });
+  }
+
+  const supabase = createClient(supabaseUrl, Deno.env.get("SUPABASE_ANON_KEY") || "");
+  const { data: authData, error: authErr } = await supabase.auth.signInWithPassword({ email: test_email, password: test_password });
+  if (authErr || !authData.session) {
+    return new Response(JSON.stringify({ error: `Auth failed: ${authErr?.message}` }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 400,
+    });
+  }
+
+  const token = authData.session.access_token;
+  const userId = authData.session.user.id;
+
+  const results: TestResult[] = await Promise.allSettled([
+    checkBusinessSearch(token),
+    checkNearestProfiles(token),
+    checkCreateBuziness(token, userId),
+  ]).then((settled) =>
+    settled.map((s) =>
+      s.status === "fulfilled"
+        ? s.value
+        : { name: "unknown", status: "fail" as const, durationMs: 0, error: String((s as PromiseRejectedResult).reason) },
+    ),
+  );
+
+  await supabase.auth.signOut();
+
+  return new Response(JSON.stringify({ results, timestamp: new Date().toISOString() }), {
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+});

--- a/supabase/functions/business-search/index.ts
+++ b/supabase/functions/business-search/index.ts
@@ -52,7 +52,7 @@ Deno.serve(async (req) => {
     });
   }
 
-  const { query, skip, take, lat, long, maxdistance, ingyen, match_threshold, query_weight, distance_weight, recommendation_weight } = await req.json();
+  const { query, skip, take, lat, long, maxdistance, ingyen, match_threshold, query_weight, distance_weight, recommendation_weight, debug } = await req.json();
 
   if (!supabaseServiceRoleKey) {
     console.error("Missing SUPABASE_SERVICE_ROLE_KEY");
@@ -70,13 +70,14 @@ Deno.serve(async (req) => {
 
   // Generate (or retrieve cached) embedding for the user's query
   let embedding = null;
+  let queryEmbeddingText: string | null = null;
   if (query && query.length > 0) {
     const normalized = query.trim().toLowerCase();
     const queryHash = await hashQuery(normalized);
 
     const { data: cached, error: cacheError } = await supabase
       .from("query_embedding_cache")
-      .select("embedding, hit_count")
+      .select("embedding, hit_count, embedding_text")
       .eq("query_hash", queryHash)
       .eq("model_version", MODEL_VERSION)
       .maybeSingle();
@@ -89,6 +90,7 @@ Deno.serve(async (req) => {
       embedding = typeof cached.embedding === "string"
         ? JSON.parse(cached.embedding)
         : cached.embedding;
+      queryEmbeddingText = cached.embedding_text ?? null;
       // Fire-and-forget: bump usage stats
       supabase
         .from("query_embedding_cache")
@@ -105,6 +107,7 @@ Deno.serve(async (req) => {
         input: query,
       });
       const embedding_text = completion.output_text;
+      queryEmbeddingText = embedding_text;
       console.log("embedding input", embedding_text);
 
       const embeddingResponse = await openai.embeddings.create({
@@ -173,7 +176,11 @@ Deno.serve(async (req) => {
     });
   }
 
-  return new Response(JSON.stringify(res.data), {
+  const responseBody = debug
+    ? JSON.stringify({ results: res.data, embedding_text: queryEmbeddingText })
+    : JSON.stringify(res.data);
+
+  return new Response(responseBody, {
     headers: { ...corsHeaders, "Content-Type": "application/json" },
   });
 });


### PR DESCRIPTION
- /app/admin/ route group (web-only, excluded from EAS native builds via .easignore)
- Test dashboard with interactive params for business-search and nearest_profiles
- Edge-case tests: create-buziness with and without contact, registration, login
- Reports viewer using service_role key to bypass RLS
- admin-health edge function for server-side test orchestration
- business-search edge function: debug=true mode returns embedding_text alongside results

https://claude.ai/code/session_01PDGKwPyJcVisrgWS2ZNKxZ