### PR TITLE
fix: wire Supabase session lifecycle into root layout for persistent login

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,7 +5,7 @@ import { persistor, store } from "@/redux/store";
 import { Stack, usePathname } from "expo-router";
 import React, { useEffect } from "react";
 import { useFonts } from "expo-font";
-import { View, StatusBar, useColorScheme, Platform } from "react-native";
+import { View, StatusBar, useColorScheme, Platform, AppState } from "react-native";
 import * as NavigationBar from "expo-navigation-bar";
 import { PaperProvider } from "react-native-paper";
 import { Provider, useSelector, useDispatch } from "react-redux";
@@ -30,8 +30,9 @@ import BuzinessSearchInput from "@/components/BuzinessSearchInput";
 import { storeBuzinesses } from "@/redux/reducers/buzinessReducer";
 import { router } from "expo-router";
 import { RootState } from "@/redux/store";
-import { setLocation } from "@/redux/reducers/userReducer";
+import { setLocation, logout } from "@/redux/reducers/userReducer";
 import { supabase } from "@/lib/supabase/supabase";
+import { fetchUserProfile } from "@/lib/auth/fetchUserProfile";
 import { registerForPushNotificationsAsync } from "@/lib/notifications/registerForPushNotifications";
 
 // Resets on hard reload (new JS execution), survives React remounts within the same page load
@@ -67,6 +68,37 @@ function RootContent() {
     if (!hasInitialized.current) {
       hasInitialized.current = true;
     }
+  }, []);
+
+  // Manage Supabase token auto-refresh based on whether app is in foreground
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (state) => {
+      if (state === "active") supabase.auth.startAutoRefresh();
+      else supabase.auth.stopAutoRefresh();
+    });
+    return () => sub.remove();
+  }, []);
+
+  // Keep Redux auth state in sync with Supabase session
+  useEffect(() => {
+    // On startup: if Redux has a uid but Supabase has no valid session, clear Redux
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (uid && !session) dispatch(logout());
+    });
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      async (event, session) => {
+        if (event === "SIGNED_OUT") {
+          // Refresh token expired or explicit sign-out from another tab/device
+          dispatch(logout());
+        } else if (event === "SIGNED_IN" && session?.user && !uid) {
+          // Session restored from storage at startup before Redux Persist loaded
+          await fetchUserProfile(session.user, dispatch);
+        }
+      }
+    );
+    return () => subscription.unsubscribe();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Fetch user location from Supabase on mount

--- a/app/csatlakozom/elso-lepesek.tsx
+++ b/app/csatlakozom/elso-lepesek.tsx
@@ -2,25 +2,16 @@ import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
 import { supabase } from "@/lib/supabase/supabase";
 import { setTutorialActive, startTutorial } from "@/redux/reducers/tutorialReducer";
-import { setName, login as sliceLogin } from "@/redux/reducers/userReducer";
 import { RootState } from "@/redux/store";
 import { UserState } from "@/redux/store.type";
-import { User } from "@supabase/auth-js";
+import { fetchUserProfile } from "@/lib/auth/fetchUserProfile";
 import { Image } from "expo-image";
 import { Link, useLocalSearchParams } from "expo-router";
 import { useEffect, useState } from "react";
-import { AppState, View } from "react-native";
+import { View } from "react-native";
 import { ActivityIndicator, Button, Icon } from "react-native-paper";
 import { Spacing } from "@/constants/spacing";
 import { useDispatch, useSelector } from "react-redux";
-
-AppState.addEventListener("change", (state) => {
-  if (state === "active") {
-    supabase.auth.startAutoRefresh();
-  } else {
-    supabase.auth.stopAutoRefresh();
-  }
-});
 
 export default function Index() {
   const dispatch = useDispatch();
@@ -36,27 +27,7 @@ export default function Index() {
   );
 
   useEffect(() => {
-    const getUserData = async (userData: User) => {
-      const { data: profile, error } = await supabase
-        .from("profiles")
-        .select("id, full_name, username, avatar_url, website, created_at, updated_at, viewed_functions")
-        .eq("id", userData.id)
-        .single();
-      if (error) {
-        setError(error.message);
-      }
-      if (profile) {
-        console.log("profile", profile);
-
-        dispatch(sliceLogin(profile?.id));
-        dispatch(setName(profile?.full_name));
-        return;
-      }
-    };
     if (token_data) {
-      //dispatch(logout());
-      console.log(token_data);
-
       supabase.auth
         .setSession({
           refresh_token: token_data.refresh_token,
@@ -64,7 +35,7 @@ export default function Index() {
         })
         .then(({ data, error }) => {
           if (error) setError(error.message);
-          if (data.user) getUserData(data.user);
+          if (data.user) fetchUserProfile(data.user, dispatch).catch((e) => setError(String(e)));
         });
     }
     dispatch(startTutorial(true));

--- a/app/csatlakozom/email-regisztracio.tsx
+++ b/app/csatlakozom/email-regisztracio.tsx
@@ -9,7 +9,7 @@ import { Redirect, router } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
 import { openBrowserAsync } from "expo-web-browser";
 import { useEffect, useState } from "react";
-import { AppState, View } from "react-native";
+import { View } from "react-native";
 
 import { addSnack } from "@/redux/reducers/infoReducer";
 import { makeRedirectUri } from "expo-auth-session";
@@ -29,14 +29,6 @@ interface SignupMetadata {
   notify_email?: boolean;
   newsletter?: boolean;
 }
-
-AppState.addEventListener("change", (state) => {
-  if (state === "active") {
-    supabase.auth.startAutoRefresh();
-  } else {
-    supabase.auth.stopAutoRefresh();
-  }
-});
 
 export default function Index() {
   const theme = useAppTheme();

--- a/app/csatlakozom/regisztracio.tsx
+++ b/app/csatlakozom/regisztracio.tsx
@@ -6,18 +6,10 @@ import { supabase } from "@/lib/supabase/supabase";
 import { makeRedirectUri } from "expo-auth-session";
 import { Link, Redirect } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
-import { AppState, View } from "react-native";
+import { View } from "react-native";
 import { Button, Divider } from "react-native-paper";
 import { useSelector } from "react-redux";
 import { Spacing } from "@/constants/spacing";
-
-AppState.addEventListener("change", (state) => {
-  if (state === "active") {
-    supabase.auth.startAutoRefresh();
-  } else {
-    supabase.auth.stopAutoRefresh();
-  }
-});
 
 export default function Index() {
   const { uid }: UserState = useSelector((state: RootState) => state.user);

--- a/app/login/index.tsx
+++ b/app/login/index.tsx
@@ -1,34 +1,21 @@
 import { ThemedView } from "@/components/ThemedView";
-import {
-  setName,
-  setUserData,
-  login as sliceLogin,
-} from "@/redux/reducers/userReducer";
+import { fetchUserProfile } from "@/lib/auth/fetchUserProfile";
 import { RootState } from "@/redux/store";
 import { UserState } from "@/redux/store.type";
 import { supabase } from "@/lib/supabase/supabase";
 import { User } from "@supabase/auth-js";
 import { Link, Redirect, router, useLocalSearchParams, useNavigation } from "expo-router";
 import { useEffect, useState } from "react";
-import { AppState, View } from "react-native";
+import { View } from "react-native";
 import { Divider, Text, TextInput } from "react-native-paper";
 import { Spacing } from "@/constants/spacing";
 import { useDispatch, useSelector } from "react-redux";
 
 import { makeRedirectUri } from "expo-auth-session";
 import * as WebBrowser from "expo-web-browser";
-import { loadViewedFunctions } from "@/redux/reducers/tutorialReducer";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Button } from "@/components/Button";
 import { useAppTheme } from "@/assets/theme";
-
-AppState.addEventListener("change", (state) => {
-  if (state === "active") {
-    supabase.auth.startAutoRefresh();
-  } else {
-    supabase.auth.stopAutoRefresh();
-  }
-});
 
 export default function Index() {
   const navigation = useNavigation();
@@ -127,42 +114,8 @@ export default function Index() {
   };
 
   const getUserData = async (userData: User) => {
-    const { data: profile } = await supabase
-      .from("profiles")
-      .select("id, full_name, username, avatar_url, website, created_at, updated_at, viewed_functions")
-      .eq("id", userData.id)
-      .maybeSingle();
-    if (error) {
-      console.log(error);
-    }
+    const profile = await fetchUserProfile(userData, dispatch);
     if (profile) {
-      console.log("profile", profile);
-
-      dispatch(sliceLogin(profile?.id));
-      dispatch(setName(profile?.full_name));
-
-      // Fetch own location via secure function
-      const { data: loc } = await supabase.rpc("get_my_profile_location");
-      const myLoc = loc?.[0];
-      const locationData = myLoc?.location_wkt
-        ? (() => {
-          const match = myLoc.location_wkt.match(/POINT\(([\d.-]+) ([\d.-]+)\)/);
-          return match
-            ? { location: { lng: parseFloat(match[1]), lat: parseFloat(match[2]) }, radius: myLoc.location_radius_m ?? 0 }
-            : undefined;
-        })()
-        : undefined;
-
-      console.log("user-data", { ...userData, ...profile });
-      dispatch(setUserData({
-        ...userData,
-        ...profile,
-        ...(locationData ? { location: locationData } : {})
-      }));
-      if (profile?.viewed_functions)
-        dispatch(loadViewedFunctions(profile?.viewed_functions));
-
-      // Navigate back to the original screen, or fall back to home
       const isValidInternal =
         typeof redirected_from === "string" &&
         redirected_from.startsWith("/") &&

--- a/lib/auth/fetchUserProfile.ts
+++ b/lib/auth/fetchUserProfile.ts
@@ -1,0 +1,41 @@
+import { User } from "@supabase/auth-js";
+import { Dispatch } from "@reduxjs/toolkit";
+import { supabase } from "@/lib/supabase/supabase";
+import { login, setName, setUserData } from "@/redux/reducers/userReducer";
+import { loadViewedFunctions } from "@/redux/reducers/tutorialReducer";
+
+export async function fetchUserProfile(user: User, dispatch: Dispatch) {
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("id, full_name, username, avatar_url, website, created_at, updated_at, viewed_functions")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (!profile) return null;
+
+  dispatch(login(profile.id));
+  dispatch(setName(profile.full_name));
+
+  const { data: loc } = await supabase.rpc("get_my_profile_location");
+  const myLoc = loc?.[0];
+  const locationData = myLoc?.location_wkt
+    ? (() => {
+        const match = myLoc.location_wkt.match(/POINT\(([\d.-]+) ([\d.-]+)\)/);
+        return match
+          ? { location: { lng: parseFloat(match[1]), lat: parseFloat(match[2]) }, radius: myLoc.location_radius_m ?? 0 }
+          : undefined;
+      })()
+    : undefined;
+
+  dispatch(setUserData({
+    ...user,
+    ...profile,
+    ...(locationData ? { location: locationData } : {}),
+  }));
+
+  if (profile.viewed_functions) {
+    dispatch(loadViewedFunctions(profile.viewed_functions));
+  }
+
+  return profile;
+}


### PR DESCRIPTION
The token auto-refresh lifecycle (startAutoRefresh/stopAutoRefresh) was
only registered at module-level in auth screens, so it was never active
once a logged-in user bypassed those screens. This caused stale access
tokens after the app returned from background, breaking authenticated API
calls (e.g. profile info not loading).

- Move AppState listener to _layout.tsx (always mounted) with proper cleanup
- Add onAuthStateChange listener to dispatch logout() when Supabase
  signals SIGNED_OUT (expired refresh token), keeping Redux in sync
- Add startup session validation: if Redux has a uid but Supabase has no
  session, clear the stale Redux state
- Extract shared fetchUserProfile util (lib/auth/fetchUserProfile.ts) to
  eliminate the duplicated profile-fetch logic in login and onboarding screens
- Remove duplicate module-level AppState listeners from 4 auth screens