### PR TITLE
fix: persistent login & freeze-after-logout

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -32,7 +32,6 @@ import { router } from "expo-router";
 import { RootState } from "@/redux/store";
 import { setLocation, logout } from "@/redux/reducers/userReducer";
 import { supabase } from "@/lib/supabase/supabase";
-import { fetchUserProfile } from "@/lib/auth/fetchUserProfile";
 import { registerForPushNotificationsAsync } from "@/lib/notifications/registerForPushNotifications";
 
 // Resets on hard reload (new JS execution), survives React remounts within the same page load
@@ -86,17 +85,12 @@ function RootContent() {
       if (uid && !session) dispatch(logout());
     });
 
-    const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      async (event, session) => {
-        if (event === "SIGNED_OUT") {
-          // Refresh token expired or explicit sign-out from another tab/device
-          dispatch(logout());
-        } else if (event === "SIGNED_IN" && session?.user && !uid) {
-          // Session restored from storage at startup before Redux Persist loaded
-          await fetchUserProfile(session.user, dispatch);
-        }
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event) => {
+      if (event === "SIGNED_OUT") {
+        // Refresh token expired or explicit sign-out — clear Redux to match
+        dispatch(logout());
       }
-    );
+    });
     return () => subscription.unsubscribe();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/app/user/edit.tsx
+++ b/app/user/edit.tsx
@@ -314,6 +314,7 @@ export default function Index() {
       console.log("User deleted successfully", data);
       setShowDeleteDialog(false);
 
+      await supabase.auth.signOut();
       dispatch(logout());
       dispatch(clearBuziness());
       dispatch(clearTutorialState());

--- a/redux/reducers/userReducer.ts
+++ b/redux/reducers/userReducer.ts
@@ -1,6 +1,5 @@
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { UserState } from "../store.type";
-import { supabase } from "@/lib/supabase/supabase";
 import { DEFAULT_THEME_PREFERENCE } from "@/assets/theme";
 
 const initialState: UserState = {
@@ -28,9 +27,6 @@ const userReducer = createSlice({
       console.log("logged in as", payload.toString());
     },
     logout: (state) => {
-      supabase.auth.signOut().then((error) => {
-        console.log(error);
-      });
       state = initialState;
       return initialState;
     },


### PR DESCRIPTION
## Summary

- **Root cause of stale auth**: `startAutoRefresh`/`stopAutoRefresh` (Supabase's token refresh lifecycle) were only registered at module-level in auth screens. When the app cold-starts with an already-logged-in user, those modules are never imported → token refresh timer never restarts after the app returns from background → API calls fail silently after a few days.
- **Root cause of freeze after logout**: The `logout` Redux reducer called `supabase.auth.signOut()`, which fired `SIGNED_OUT` via `onAuthStateChange`, which dispatched `logout()` again → infinite loop.
- **Login infinite-loading** (secondary fix): A `SIGNED_IN` handler in the root layout was racing with the login screen's own flow, causing `Stack.Protected` to flip mid-login.

## Changes

| File | What changed |
|---|---|
| `app/_layout.tsx` | Move `AppState` listener here (always mounted, with cleanup). Add `onAuthStateChange` to dispatch `logout()` on `SIGNED_OUT` and validate session on startup. |
| `redux/reducers/userReducer.ts` | Remove `supabase.auth.signOut()` from reducer — side effects don't belong here. |
| `app/user/edit.tsx` | Call `supabase.auth.signOut()` explicitly before `dispatch(logout())` in the delete-account flow. |
| `lib/auth/fetchUserProfile.ts` | New shared util — extracts the duplicated profile-fetch logic from login and onboarding screens. |
| `app/login/index.tsx` | Remove duplicate `AppState` listener; use shared `fetchUserProfile`. |
| `app/csatlakozom/regisztracio.tsx` | Remove duplicate `AppState` listener. |
| `app/csatlakozom/email-regisztracio.tsx` | Remove duplicate `AppState` listener. |
| `app/csatlakozom/elso-lepesek.tsx` | Remove duplicate `AppState` listener; use shared `fetchUserProfile`. |

## Test plan

- [ ] Log in → confirm it works without infinite loading
- [ ] Force-kill app, reopen → user stays logged in, profile info loads
- [ ] Use app for a session, background it for an extended period, foreground → token refreshes silently, profile still loads
- [ ] Delete account → app navigates to deleted-account screen without freezing
- [ ] Simulate expired session (clear Supabase AsyncStorage keys) → app redirects to login screen instead of broken state

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwFsvHvk6raJPLY9uqUaxX)_