### PR TITLE
Redesign biznisz detail page with hero + sticky tabs

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -21,6 +21,7 @@ export default {
     }
   },
   android: {
+    softwareKeyboardLayoutMode: "resize",
     splash: {
       image: "./assets/images/Slimey.png",
       resizeMode: "contain",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -163,7 +163,7 @@ function RootContent() {
                 />
                 <Stack.Screen
                   name="biznisz/index"
-                  options={{ title: "Biznisz" }}
+                  options={{ title: "Bizniszek keresése" }}
                 />
 
                 <Stack.Screen
@@ -172,19 +172,19 @@ function RootContent() {
                 />
                 <Stack.Screen
                   name="biznisz/[id]"
-                  options={{ title: "FiFe Biznisz" }}
+                  options={{ title: "Biznisz" }}
                 />
                 <Stack.Screen
                   name="biznisz/edit/[editId]"
-                  options={{ title: "FiFe Biznisz" }}
+                  options={{ title: "Biznisz szerkesztése" }}
                 />
                 <Stack.Screen
                   name="user/[uid]"
-                  options={{ title: "FiFe Profil" }}
+                  options={{ title: "Profil" }}
                 />
                 <Stack.Screen
                   name="user/edit"
-                  options={{ title: "Profil Szerkesztése" }}
+                  options={{ title: "Profil szerkesztése" }}
                 />
               </Stack.Protected>
 

--- a/app/biznisz/[id].tsx
+++ b/app/biznisz/[id].tsx
@@ -1,23 +1,34 @@
 import MyLocationIcon from "@/assets/images/myLocationIcon";
+import { useAppTheme } from "@/assets/theme";
 import CollapsibleText from "@/components/CollapsibleText";
 import ErrorScreen from "@/components/ErrorScreen";
 import ProfileImage from "@/components/ProfileImage";
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
 import BuzinessRecommendationsModal from "@/components/buziness/BuzinessRecommendationsModal";
-import { ContactList } from "@/components/buziness/ContactList";
+import ContactsCard from "@/components/buziness/ContactsCard";
+import SectionLabel from "@/components/buziness/SectionLabel";
 import Comments from "@/components/comments/Comments";
-import { LatLng, Marker } from "@/components/mapView/mapView";
+import UrlText from "@/components/comments/UrlText";
 import FiFeMap from "@/components/mapView/FiFeMap";
+import { LatLng, Marker } from "@/components/mapView/mapView";
+import { MyAppbar } from "@/components/MyAppBar";
+import CategoryChip from "@/components/CategoryChip";
+import { BorderRadius } from "@/constants/borderRadius";
+import { Spacing } from "@/constants/spacing";
 import { Tables } from "@/database.types";
 import { useMyLocation } from "@/hooks/useMyLocation";
+import elapsedTime from "@/lib/functions/elapsedTime";
+import toDistanceText from "@/lib/functions/distanceText";
+import getDistance from "@/lib/functions/getDistance";
 import getImagesUrlFromSupabase from "@/lib/functions/getImagesUrlFromSupabase";
 import getLinkForContact from "@/lib/functions/getLinkForContact";
 import locationToCoords from "@/lib/functions/locationToCoords";
+import typeToIcon from "@/lib/functions/typeToIcon";
 import { RecommendBuzinessButton } from "@/lib/supabase/RecommendBuzinessButton";
 import { SaveBuzinessButton } from "@/lib/supabase/SaveBuzinessButton";
 import { supabase } from "@/lib/supabase/supabase";
-import { storeBuzinessSearchParams } from "@/redux/reducers/buzinessReducer";
+import { clearOptions, setOptions } from "@/redux/reducers/infoReducer";
 import { RootState } from "@/redux/store";
 import {
   BuzinessItemInterface,
@@ -32,7 +43,7 @@ import {
   useFocusEffect,
   useGlobalSearchParams,
 } from "expo-router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ScrollView, useWindowDimensions, View } from "react-native";
 import ImageModal from "react-native-image-modal";
 import openMap from "react-native-open-maps";
@@ -41,22 +52,61 @@ import {
   Button,
   IconButton,
   Portal,
+  Surface,
   Text,
   TouchableRipple,
 } from "react-native-paper";
-// Removed tabs; sections will be stacked vertically
 import { useDispatch, useSelector } from "react-redux";
-import { MyAppbar } from "@/components/MyAppBar";
-import typeToIcon from "@/lib/functions/typeToIcon";
-import UrlText from "@/components/comments/UrlText";
-import { clearOptions, setOptions } from "@/redux/reducers/infoReducer";
-import CategoryChip from "@/components/CategoryChip";
-import { useAppTheme } from "@/assets/theme";
+
+const StatDivider = () => {
+  const theme = useAppTheme();
+  return (
+    <View
+      style={{
+        width: 1,
+        backgroundColor: theme.colors.outlineVariant,
+        marginVertical: Spacing.xs,
+      }}
+    />
+  );
+};
+
+const StatItem = ({
+  value,
+  label,
+  onPress,
+}: {
+  value: string | number | null;
+  label: string;
+  onPress?: () => void;
+}) => {
+  const theme = useAppTheme();
+  const inner = (
+    <View style={{ alignItems: "center", paddingVertical: Spacing.xs }}>
+      <Text variant="headlineSmall" style={{ fontWeight: "700", color: theme.colors.primary }}>
+        {value}
+      </Text>
+      <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant }}>
+        {label}
+      </Text>
+    </View>
+  );
+  return onPress ? (
+    <TouchableRipple
+      onPress={onPress}
+      style={{ flex: 1, alignItems: "center", borderRadius: BorderRadius.md }}
+    >
+      {inner}
+    </TouchableRipple>
+  ) : (
+    <View style={{ flex: 1 }}>{inner}</View>
+  );
+};
 
 export default function Index() {
   const theme = useAppTheme();
+  const { height: windowHeight } = useWindowDimensions();
   const { id: paramId } = useGlobalSearchParams();
-  const { width } = useWindowDimensions();
   const dispatch = useDispatch();
   const { uid: myUid }: UserState = useSelector(
     (state: RootState) => state.user
@@ -65,6 +115,7 @@ export default function Index() {
   const [data, setData] = useState<BuzinessItemInterface | undefined>();
   const [defaultContact, setDefaultContact] =
     useState<Tables<"contacts"> | null>();
+  const [contacts, setContacts] = useState<Tables<"contacts">[]>([]);
   const [error, setError] = useState<null | Partial<PostgrestError>>(null);
   const [recommendations, setRecommendations] = useState<string[]>([]);
   const [showRecommendsModal, setShowRecommendsModal] = useState(false);
@@ -81,6 +132,38 @@ export default function Index() {
   const { myLocation } = useMyLocation();
   const [commentsCount, setCommentsCount] = useState<number>();
   const isNew = data?.created_at && new Date().getTime() - new Date(data.created_at).getTime() < 1000 * 60 * 60 * 24 * 10;
+
+  const scrollRef = useRef<ScrollView>(null);
+  const [tab, setTab] = useState<"overview" | "reviews">("overview");
+  // Height of the (non-sticky) header block. Since it sits at y=0, its height
+  // equals the sticky tab bar's scroll offset. Measuring the header instead of
+  // the sticky tab bar avoids reading a translated/stale Y from the sticky node.
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const tabBarY = headerHeight + Spacing.xl; // header block has marginBottom: Spacing.xl
+
+  const goToTab = (next: "overview" | "reviews") => {
+    setTab(next);
+    // allow the new tab content to mount/lay out before scrolling to the tab bar
+    setTimeout(() => scrollRef.current?.scrollTo({ y: tabBarY, animated: true }), 50);
+  };
+
+  const goToMap = () => {
+    setTab("overview");
+    // allow the overview tab to mount/lay out before scrolling to the map (last element)
+    setTimeout(() => scrollRef.current?.scrollToEnd({ animated: true }), 50);
+  };
+
+  const distanceMeters =
+    myLocation && location
+      ? getDistance(
+          myLocation.coords.latitude,
+          myLocation.coords.longitude,
+          location.latitude,
+          location.longitude
+        )
+      : null;
+  const distanceText =
+    distanceMeters != null ? toDistanceText(distanceMeters / 1000) : null;
 
   useEffect(() => {
     if (myBuziness)
@@ -119,7 +202,6 @@ export default function Index() {
               setError(error);
               return;
             }
-            console.log(data?.location);
 
             if (data) {
               const cords = data?.location
@@ -143,6 +225,15 @@ export default function Index() {
               setRecommendations(
                 data?.buzinessRecommendations?.map((pr) => pr.author)
               );
+
+              if (data.author)
+                supabase
+                  .from("contacts")
+                  .select("*")
+                  .eq("author", data.author)
+                  .then((res) => {
+                    if (res.data) setContacts(res.data);
+                  });
             } else
               setError({
                 code: "jaj basszus",
@@ -155,8 +246,6 @@ export default function Index() {
           .eq("key", "buziness/" + id)
           .single()
           .then((res) => {
-            console.log(res);
-
             setCommentsCount(res.data?.count);
           });
       };
@@ -172,175 +261,226 @@ export default function Index() {
     <>
       <Stack.Screen options={{
         header: () => <MyAppbar
-          center={data?.title ?
-            <Text variant="titleLarge">{title}</Text> : undefined}
-          style={{ elevation: 0, shadowOpacity: 0, borderBottomWidth: 0, backgroundColor: theme.colors.background }} />
+          title="Biznisz"
+          style={{ elevation: 0, shadowOpacity: 0, borderBottomWidth: 0 }} />
       }} />
       <ThemedView style={{ flex: 1 }}>
-        <ScrollView >
-          {!data && !error && <ActivityIndicator />}
-          {!!id && !!data && (
-            <>
-              <View
+        {!data && !error && (
+          <View style={{ paddingTop: Spacing.xxxl, alignItems: "center" }}>
+            <ActivityIndicator />
+          </View>
+        )}
+        {!!error && (
+          <ErrorScreen
+            icon="briefcase-off"
+            title={error.code}
+            text={error.message}
+          />
+        )}
+        {!!id && !!data && (
+          <ScrollView
+            ref={scrollRef}
+            stickyHeaderIndices={[1]}
+            contentContainerStyle={{ paddingBottom: Spacing.xxl }}
+          >
+            {/* HEADER (index 0) */}
+            <View
+              style={{ marginBottom: Spacing.xl }}
+              onLayout={(e) => setHeaderHeight(e.nativeEvent.layout.height)}
+            >
+              {/* HERO */}
+              <ThemedView
                 style={{
-                  flexWrap: "wrap",
-                  flexDirection: "row",
-                  gap: 4,
-                  paddingHorizontal: 10,
+                  paddingHorizontal: Spacing.md,
+                  paddingTop: Spacing.xxl,
+                  gap: Spacing.xl,
                 }}
               >
-                {!!isNew && (
-                  <CategoryChip key="category-new" style={{ backgroundColor: theme.colors.tertiary }} textStyle={{ color: theme.colors.onTertiary }}>új</CategoryChip>
-                )}
-                {!!data.ingyen && (
-                  <CategoryChip key="category-ingyen" style={{ backgroundColor: theme.colors.nature }} textStyle={{ color: theme.colors.onNature }}>ingyenes</CategoryChip>
-                )}
-                {categories?.slice(1).map((e, i) => {
-                  if (e.trim())
-                    return (
-                      <CategoryChip key={"category" + i}>{e}</CategoryChip>
-                    );
-                })}
-              </View>
-              <CollapsibleText>
-                <UrlText text={data.description} />
-              </CollapsibleText>
-              <View style={{ width: "100%", flexDirection: "row", alignItems: "flex-start" }}>
-                <Link
-                  asChild
-                  style={{ flex: 1, padding: 8, justifyContent: "center" }}
-                  href={{ pathname: "/user/[uid]", params: { uid: data.author } }}
-                >
-                  <TouchableRipple>
-                    <View
-                      style={{
-                        flexDirection: "row",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        gap: 8
-                      }}
-                    >
-                      <ProfileImage
-                        uid={data.author}
-                        style={{
-                          width: 30,
-                          height: 30,
-                          borderRadius: 30,
-                          margin: 4,
-                        }}
-                        avatar_url={data.avatarUrl}
-                      />
-                      <Text style={{ textAlign: "center" }}>
-                        {data.authorName} biznisze
-                      </Text>
-                    </View>
-                  </TouchableRipple>
-                </Link>
-                <TouchableRipple
-                  style={{
-                    flex: 1,
-                    alignItems: "center",
-                    justifyContent: "center", padding: 8,
-                    paddingLeft: 24,
-                    height: 55
-                  }}
-                  onPress={
-                    recommendations?.length
-                      ? () => setShowRecommendsModal(true)
-                      : undefined
-                  }
-                >
-                  <Text style={{ textAlign: "center" }}>
-                    {recommendations?.length
-                      ? recommendations?.length + " ajánlás"
-                      : "Még senki sem ajánlja"}
-                  </Text>
-                </TouchableRipple>
-              </View>
-              <View style={{ gap: 4, padding: 4 }}>
-                {defaultContact && (
-                  <Link asChild href={getLinkForContact(defaultContact)} style={{ width: "100%" }}>
-                    <Button mode="contained-tonal" icon={typeToIcon(defaultContact.type)}>
-                      {defaultContact.title || defaultContact?.data}
-                    </Button>
-                  </Link>
-                )}
+                {/* Title + chips + byline */}
+                <View style={{ gap: Spacing.sm }}>
+                  <Text variant="headlineLarge">{title}</Text>
 
-                {!myBuziness && (
-                  <View style={{ flexDirection: "row", alignItems: "center", width: "100%" }}>
-                    <RecommendBuzinessButton
-                      buzinessId={id}
-                      style={{ flex: 1 }}
-                      recommended={iRecommended}
-                      setRecommended={(recommendedByMe) => {
-                        if (myUid) {
-                          if (recommendedByMe)
-                            setRecommendations([...recommendations, myUid]);
-                          else
-                            setRecommendations(
-                              recommendations.filter((uid) => uid !== myUid)
-                            );
-                        }
-                      }}
-                    />
-                    <SaveBuzinessButton
-                      buzinessId={id}
-                    />
-                  </View>
-                )}
-              </View>
-              {/* Vertical sections instead of tabs */}
-              {data.location && (
-                <View style={{ marginTop: 8 }}>
-                  <Text variant="titleMedium" style={{ marginHorizontal: 8, marginBottom: 6 }}>Helyzete</Text>
-                  <View style={{ minHeight: 200, flex: 1 }}>
-                    <FiFeMap
-                      style={{ width: "100%", height: 240 }}
-                      initialCamera={location ? { center: location } : undefined}
-                    >
-                      {location && <Marker coordinate={location} />}
-                      {myLocation && (
-                        <Marker
-                          centerOffset={{ x: 10, y: 10 }}
-                          coordinate={myLocation?.coords}
-                          style={{ justifyContent: "center", alignItems: "center" }}
-                        >
-                          <MyLocationIcon style={{ width: 20, height: 20 }} />
-                        </Marker>
-                      )}
-                    </FiFeMap>
-                    {location && (
-                      <IconButton
-                        icon="directions"
-                        mode="contained"
-                        onPress={() =>
-                          openMap({
-                            latitude: location.latitude,
-                            longitude: location.longitude,
-                            navigate: true,
-                            start: "My Location",
-                            travelType: "public_transport",
-                            end: location.latitude + "," + location.longitude,
-                          })
-                        }
-                        style={{ right: 4, bottom: 17, position: "absolute" }}
-                      />
+                  <View
+                    style={{
+                      flexDirection: "row",
+                      flexWrap: "wrap",
+                      gap: Spacing.xs,
+                    }}
+                  >
+                    {!!isNew && (
+                      <CategoryChip key="category-new" style={{ backgroundColor: theme.colors.tertiary }} textStyle={{ color: theme.colors.onTertiary }}>új</CategoryChip>
                     )}
+                    {!!data.ingyen && (
+                      <CategoryChip key="category-ingyen" style={{ backgroundColor: theme.colors.nature }} textStyle={{ color: theme.colors.onNature }}>ingyenes</CategoryChip>
+                    )}
+                    {categories?.slice(1).map((e, i) => {
+                      if (e.trim())
+                        return (
+                          <CategoryChip key={"category" + i}>{e}</CategoryChip>
+                        );
+                    })}
                   </View>
-                </View>
-              )}
 
+                  <Link
+                    asChild
+                    href={{ pathname: "/user/[uid]", params: { uid: data.author } }}
+                  >
+                    <TouchableRipple style={{ borderRadius: BorderRadius.sm, alignSelf: "flex-start" }}>
+                      <View
+                        style={{
+                          flexDirection: "row",
+                          alignItems: "center",
+                          gap: Spacing.xs,
+                          paddingVertical: Spacing.xs,
+                        }}
+                      >
+                        <ProfileImage
+                          uid={data.author}
+                          style={{ width: 24, height: 24, borderRadius: BorderRadius.full }}
+                          avatar_url={data.avatarUrl}
+                        />
+                        <Text variant="labelMedium" style={{ color: theme.colors.onSurfaceVariant }}>
+                          {data.authorName} biznisze
+                        </Text>
+                      </View>
+                    </TouchableRipple>
+                  </Link>
+                </View>
+
+                {/* Description */}
+                {!!data.description && (
+                  <CollapsibleText style={{ paddingHorizontal: 0, paddingVertical: Spacing.xs }}>
+                    <UrlText text={data.description} style={{ fontSize: 15, lineHeight: 22 }} />
+                  </CollapsibleText>
+                )}
+
+                {/* Stats card */}
+                <Surface
+                  style={{
+                    flexDirection: "row",
+                    borderRadius: BorderRadius.lg,
+                    paddingVertical: Spacing.md,
+                    paddingHorizontal: Spacing.lg,
+                    width: "100%",
+                  }}
+                  elevation={1}
+                >
+                  <StatItem
+                    value={recommendations?.length ?? 0}
+                    label="Ajánlás"
+                    onPress={
+                      recommendations?.length
+                        ? () => setShowRecommendsModal(true)
+                        : undefined
+                    }
+                  />
+
+                  <StatDivider />
+
+                  <StatItem
+                    value={commentsCount ?? 0}
+                    label="Vélemény"
+                    onPress={() => goToTab("reviews")}
+                  />
+
+                  {distanceText ? (
+                    <>
+                      <StatDivider />
+                      <StatItem
+                        value={distanceText}
+                        label="Távolság"
+                        onPress={data.location ? goToMap : undefined}
+                      />
+                    </>
+                  ) : data.created_at ? (
+                    <>
+                      <StatDivider />
+                      <StatItem
+                        value={elapsedTime(Date.parse(data.created_at.toString()))}
+                        label="Kora"
+                      />
+                    </>
+                  ) : null}
+                </Surface>
+
+                {/* Primary CTA + secondary actions */}
+                <View style={{ gap: Spacing.sm }}>
+                  {myBuziness ? (
+                    <Link asChild href={{ pathname: "/biznisz/edit/[editId]", params: { editId: id } }}>
+                      <Button
+                        mode="contained-tonal"
+                        icon="pencil"
+                        style={{ borderRadius: BorderRadius.pill, width: "100%" }}
+                      >
+                        Biznisz szerkesztése
+                      </Button>
+                    </Link>
+                  ) : defaultContact ? (
+                    <Link asChild href={getLinkForContact(defaultContact)}>
+                      <Button
+                        mode="contained"
+                        icon={typeToIcon(defaultContact.type)}
+                        contentStyle={{ height: 50 }}
+                        labelStyle={{ fontSize: 16 }}
+                        style={{ borderRadius: BorderRadius.pill, width: "100%" }}
+                      >
+                        {defaultContact.title || defaultContact?.data}
+                      </Button>
+                    </Link>
+                  ) : (
+                    <Button
+                      mode="contained"
+                      icon="card-account-phone"
+                      contentStyle={{ height: 50 }}
+                      labelStyle={{ fontSize: 16 }}
+                      style={{ borderRadius: BorderRadius.pill, width: "100%" }}
+                      disabled={contacts.length === 0}
+                      onPress={() => goToTab("overview")}
+                    >
+                      Kapcsolat
+                    </Button>
+                  )}
+
+                  {!myBuziness && (
+                    <View style={{ flexDirection: "row", alignItems: "center", gap: Spacing.sm }}>
+                      <RecommendBuzinessButton
+                        buzinessId={id}
+                        mode="outlined"
+                        style={{ flex: 1, borderRadius: BorderRadius.pill }}
+                        recommended={iRecommended}
+                        setRecommended={(recommendedByMe) => {
+                          if (myUid) {
+                            if (recommendedByMe)
+                              setRecommendations([...recommendations, myUid]);
+                            else
+                              setRecommendations(
+                                recommendations.filter((uid) => uid !== myUid)
+                              );
+                          }
+                        }}
+                      />
+                      <SaveBuzinessButton buzinessId={id} />
+                    </View>
+                  )}
+                </View>
+              </ThemedView>
+
+              {/* IMAGES — horizontal carousel */}
               {images.length > 0 && (
-                <View style={{ marginTop: 16 }}>
-                  <Text variant="titleMedium" style={{ marginHorizontal: 8, marginBottom: 6 }}>Képek</Text>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  style={{ marginTop: Spacing.xl }}
+                  contentContainerStyle={{ paddingHorizontal: Spacing.md, gap: Spacing.sm }}
+                >
                   {images.map((image, ind) => (
-                    <View key={"image-" + ind} style={{ width: "100%" }}>
+                    <View key={"image-" + ind} style={{ width: 160 }}>
                       <ImageModal
                         source={{ uri: image.url }}
-                        resizeMode="contain"
+                        resizeMode="cover"
                         modalImageResizeMode="contain"
                         overlayBackgroundColor="#00000096"
-                        style={{ width: width, height: 200 }}
+                        style={{ width: 160, height: 160, borderRadius: BorderRadius.lg }}
                         renderFooter={() => (
                           <ScrollView style={{ maxHeight: 250 }}>
                             <ThemedText style={{ color: "white", textShadowColor: "black", textShadowRadius: 3 }}>
@@ -349,45 +489,155 @@ export default function Index() {
                           </ScrollView>
                         )}
                       />
-                      <View style={{ padding: 4 }}>
-                        <CollapsibleText>
+                      {!!image.description && (
+                        <Text
+                          variant="labelSmall"
+                          numberOfLines={1}
+                          style={{ color: theme.colors.onSurfaceVariant, paddingTop: Spacing.xs }}
+                        >
                           {image.description}
-                        </CollapsibleText>
-                      </View>
+                        </Text>
+                      )}
                     </View>
                   ))}
-                </View>
+                </ScrollView>
               )}
 
-              <View style={{ marginTop: 16 }}>
-                <Text variant="titleMedium" style={{ marginHorizontal: 8, marginBottom: 6 }}>Elérhetőségek</Text>
-                <ContactList uid={data.author} />
-              </View>
+            </View>
 
-              <View style={{ marginTop: 16 }}>
-                <Text variant="titleMedium" style={{ marginHorizontal: 8, marginBottom: 6 }}>Vélemények</Text>
-                <Comments path={"buziness/" + id} placeholder="Mondd el a véleményed" />
-              </View>
-            </>
-          )}
-          {!!title && (
-            <Portal>
-              <BuzinessRecommendationsModal
-                show={showRecommendsModal}
-                setShow={setShowRecommendsModal}
-                id={id}
-                name={title}
-              />
-            </Portal>
-          )}
-          {!!error && (
-            <ErrorScreen
-              icon="briefcase-off"
-              title={error.code}
-              text={error.message}
+            {/* TAB BAR (sticky index 1) */}
+            <View
+              style={{
+                flexDirection: "row",
+                backgroundColor: theme.colors.background,
+                borderBottomWidth: 1,
+                borderBottomColor: theme.colors.outlineVariant,
+              }}
+            >
+              {(
+                [
+                  { key: "overview", label: "Áttekintés" },
+                  {
+                    key: "reviews",
+                    label: commentsCount
+                      ? `Vélemények (${commentsCount})`
+                      : "Vélemények",
+                  },
+                ] as const
+              ).map((t) => {
+                const active = tab === t.key;
+                return (
+                  <TouchableRipple key={t.key} style={{ flex: 1 }} onPress={() => setTab(t.key)}>
+                    <View
+                      style={{
+                        alignItems: "center",
+                        paddingVertical: Spacing.md,
+                        borderBottomWidth: 2,
+                        borderBottomColor: active ? theme.colors.primary : "transparent",
+                      }}
+                    >
+                      <Text
+                        variant="labelLarge"
+                        style={{ color: active ? theme.colors.onSurface : theme.colors.onSurfaceVariant }}
+                      >
+                        {t.label}
+                      </Text>
+                    </View>
+                  </TouchableRipple>
+                );
+              })}
+            </View>
+
+            {/* TAB CONTENT (index 2) */}
+            {/* minHeight keeps the content below the sticky tab bar at least a
+                screenful tall, so jumping to a tab can always scroll the tab
+                bar up to the top even when a tab's content is short. */}
+            <View style={{ paddingTop: Spacing.xl, minHeight: windowHeight }}>
+              {tab === "overview" ? (
+                <View style={{ gap: Spacing.xl }}>
+                  {contacts.length > 0 && (
+                    <View style={{ paddingHorizontal: Spacing.md, gap: Spacing.sm }}>
+                      <SectionLabel label="Elérhetőségek" />
+                      <ContactsCard contacts={contacts} />
+                    </View>
+                  )}
+
+                  {!!data.location && (
+                    <View style={{ paddingHorizontal: Spacing.md, gap: Spacing.sm }}>
+                      <SectionLabel label="Helyzete" />
+                      <View
+                        style={{
+                          height: 240,
+                          borderRadius: BorderRadius.lg,
+                          overflow: "hidden",
+                        }}
+                      >
+                        <FiFeMap
+                          style={{ width: "100%", height: "100%" }}
+                          initialCamera={location ? { center: location } : undefined}
+                        >
+                          {location && <Marker coordinate={location} />}
+                          {myLocation && (
+                            <Marker
+                              centerOffset={{ x: 10, y: 10 }}
+                              coordinate={myLocation?.coords}
+                              style={{ justifyContent: "center", alignItems: "center" }}
+                            >
+                              <MyLocationIcon style={{ width: 20, height: 20 }} />
+                            </Marker>
+                          )}
+                        </FiFeMap>
+                        {location && (
+                          <IconButton
+                            icon="directions"
+                            mode="contained"
+                            onPress={() =>
+                              openMap({
+                                latitude: location.latitude,
+                                longitude: location.longitude,
+                                navigate: true,
+                                start: "My Location",
+                                travelType: "public_transport",
+                                end: location.latitude + "," + location.longitude,
+                              })
+                            }
+                            style={{ right: Spacing.xs, bottom: Spacing.xs, position: "absolute" }}
+                          />
+                        )}
+                      </View>
+                    </View>
+                  )}
+
+                  {contacts.length === 0 && !data.location && (
+                    <ThemedText
+                      style={{
+                        textAlign: "center",
+                        color: theme.colors.onSurfaceVariant,
+                        padding: Spacing.lg,
+                      }}
+                    >
+                      Nincs megadva elérhetőség vagy helyszín.
+                    </ThemedText>
+                  )}
+                </View>
+              ) : (
+                <View style={{ paddingHorizontal: Spacing.md }}>
+                  <Comments path={"buziness/" + id} placeholder="Mondd el a véleményed" />
+                </View>
+              )}
+            </View>
+          </ScrollView>
+        )}
+        {!!title && (
+          <Portal>
+            <BuzinessRecommendationsModal
+              show={showRecommendsModal}
+              setShow={setShowRecommendsModal}
+              id={id}
+              name={title}
             />
-          )}
-        </ScrollView>
+          </Portal>
+        )}
       </ThemedView>
     </>
   );

--- a/app/biznisz/[id].tsx
+++ b/app/biznisz/[id].tsx
@@ -44,7 +44,7 @@ import {
   useGlobalSearchParams,
 } from "expo-router";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ScrollView, useWindowDimensions, View } from "react-native";
+import { KeyboardAvoidingView, Platform, ScrollView, useWindowDimensions, View } from "react-native";
 import ImageModal from "react-native-image-modal";
 import openMap from "react-native-open-maps";
 import {
@@ -193,7 +193,7 @@ export default function Index() {
         supabase
           .from("buziness")
           .select(
-            "*, contacts(*), profiles ( full_name, avatar_url ), buzinessRecommendations!buzinessRecommendations_buziness_id_fkey(author)"
+            "*, profiles ( full_name, avatar_url ), buzinessRecommendations!buzinessRecommendations_buziness_id_fkey(author)"
           )
           .eq("id", id)
           .maybeSingle()
@@ -204,6 +204,8 @@ export default function Index() {
               return;
             }
 
+            console.log(data);
+            
             if (data) {
               const cords = data?.location
                 ? locationToCoords(String(data.location))
@@ -216,38 +218,43 @@ export default function Index() {
                 authorName: data?.profiles?.full_name || "???",
                 avatarUrl: data?.profiles?.avatar_url,
               });
-              if (data.images) setImages(getImagesUrlFromSupabase(data.images));
-              if (data.defaultContact) {
-                if (data.contacts) {
-                  setDefaultContact(data.contacts);
-                }
-              }
+
+
 
               setRecommendations(
                 data?.buzinessRecommendations?.map((pr) => pr.author)
               );
 
-              if (data.author)
+              if (data.author){
                 supabase
                   .from("contacts")
                   .select("*")
                   .eq("author", data.author)
                   .then((res) => {
+                    console.log("contact res",res);
+                    
                     const fetched = res.data ?? [];
+                    
+                    setDefaultContact(fetched.find(c=>c.id==data.defaultContact));
                     if (fetched.length > 0) {
                       setContacts(fetched);
-                    } else if (data.contacts) {
-                      setContacts([data.contacts]);
-                    } else {
-                      setContacts([]);
                     }
                   });
-            } else
-              setError({
-                code: "jaj basszus",
-                message: "Ez a biznisz nem található",
-              });
+              }} else{
+                setError({
+                  code: "jaj basszus",
+                  message: "Ez a biznisz nem található",
+                });}
+
+              try {
+                if (data?.images) setImages(getImagesUrlFromSupabase(data.images));
+              } catch (error) {
+                console.log("image error");
+                
+              }
+              
           });
+
         supabase
           .from("comments")
           .select("count")
@@ -272,6 +279,11 @@ export default function Index() {
           title="Biznisz"
           style={{ elevation: 0, shadowOpacity: 0, borderBottomWidth: 0 }} />
       }} />
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={Platform.OS === "ios" ? 56 : 0}
+      >
       <ThemedView style={{ flex: 1 }}>
         {!data && !error && (
           <View style={{ paddingTop: Spacing.xxxl, alignItems: "center" }}>
@@ -289,6 +301,8 @@ export default function Index() {
           <ScrollView
             ref={scrollRef}
             stickyHeaderIndices={[1]}
+            automaticallyAdjustKeyboardInsets
+            keyboardShouldPersistTaps="handled"
             contentContainerStyle={{ paddingBottom: Spacing.xxl, minHeight: windowHeight+ 100 }}
           >
             {/* HEADER (index 0) */}
@@ -562,7 +576,7 @@ export default function Index() {
             {/* minHeight keeps the content below the sticky tab bar at least a
                 screenful tall, so jumping to a tab can always scroll the tab
                 bar up to the top even when a tab's content is short. */}
-            <View style={{ paddingTop: Spacing.xl }}>
+            <View style={{ paddingTop: Spacing.xl, minHeight: windowHeight/2, flex:1 }}>
               {tab === "overview" ? (
                 <View style={{ gap: Spacing.xl }}>
                   {contacts.length > 0 && (
@@ -633,7 +647,7 @@ export default function Index() {
                   )}
                 </View>
               ) : (
-                <View style={{ paddingHorizontal: Spacing.md }}>
+                <View style={{ paddingHorizontal: Spacing.md}}>
                   <Comments path={"buziness/" + id} placeholder="Mondd el a véleményed" />
                 </View>
               )}
@@ -651,6 +665,7 @@ export default function Index() {
           </Portal>
         )}
       </ThemedView>
+      </KeyboardAvoidingView>
     </>
   );
 }

--- a/app/biznisz/[id].tsx
+++ b/app/biznisz/[id].tsx
@@ -116,6 +116,7 @@ export default function Index() {
   const [defaultContact, setDefaultContact] =
     useState<Tables<"contacts"> | null>();
   const [contacts, setContacts] = useState<Tables<"contacts">[]>([]);
+
   const [error, setError] = useState<null | Partial<PostgrestError>>(null);
   const [recommendations, setRecommendations] = useState<string[]>([]);
   const [showRecommendsModal, setShowRecommendsModal] = useState(false);
@@ -232,7 +233,14 @@ export default function Index() {
                   .select("*")
                   .eq("author", data.author)
                   .then((res) => {
-                    if (res.data) setContacts(res.data);
+                    const fetched = res.data ?? [];
+                    if (fetched.length > 0) {
+                      setContacts(fetched);
+                    } else if (data.contacts) {
+                      setContacts([data.contacts]);
+                    } else {
+                      setContacts([]);
+                    }
                   });
             } else
               setError({
@@ -281,7 +289,7 @@ export default function Index() {
           <ScrollView
             ref={scrollRef}
             stickyHeaderIndices={[1]}
-            contentContainerStyle={{ paddingBottom: Spacing.xxl }}
+            contentContainerStyle={{ paddingBottom: Spacing.xxl, minHeight: windowHeight+ 100 }}
           >
             {/* HEADER (index 0) */}
             <View
@@ -298,7 +306,7 @@ export default function Index() {
               >
                 {/* Title + chips + byline */}
                 <View style={{ gap: Spacing.sm }}>
-                  <Text variant="headlineLarge">{title}</Text>
+                  <ThemedText variant="headlineLarge">{title}</ThemedText>
 
                   <View
                     style={{
@@ -506,53 +514,55 @@ export default function Index() {
             </View>
 
             {/* TAB BAR (sticky index 1) */}
-            <View
-              style={{
-                flexDirection: "row",
-                backgroundColor: theme.colors.background,
-                borderBottomWidth: 1,
-                borderBottomColor: theme.colors.outlineVariant,
-              }}
-            >
-              {(
-                [
-                  { key: "overview", label: "Áttekintés" },
-                  {
-                    key: "reviews",
-                    label: commentsCount
-                      ? `Vélemények (${commentsCount})`
-                      : "Vélemények",
-                  },
-                ] as const
-              ).map((t) => {
-                const active = tab === t.key;
-                return (
-                  <TouchableRipple key={t.key} style={{ flex: 1 }} onPress={() => setTab(t.key)}>
-                    <View
-                      style={{
-                        alignItems: "center",
-                        paddingVertical: Spacing.md,
-                        borderBottomWidth: 2,
-                        borderBottomColor: active ? theme.colors.primary : "transparent",
-                      }}
-                    >
-                      <Text
-                        variant="labelLarge"
-                        style={{ color: active ? theme.colors.onSurface : theme.colors.onSurfaceVariant }}
+            <View>
+              <View
+                style={{
+                  flexDirection: "row",
+                  backgroundColor: theme.colors.background,
+                  borderBottomWidth: 1,
+                  borderBottomColor: theme.colors.outlineVariant,
+                }}
+              >
+                {(
+                  [
+                    { key: "overview", label: "Áttekintés" },
+                    {
+                      key: "reviews",
+                      label: commentsCount
+                        ? `Vélemények (${commentsCount})`
+                        : "Vélemények",
+                    },
+                  ] as const
+                ).map((t) => {
+                  const active = tab === t.key;
+                  return (
+                    <TouchableRipple key={t.key} style={{ flex: 1 }} onPress={() => setTab(t.key)}>
+                      <View
+                        style={{
+                          alignItems: "center",
+                          paddingVertical: Spacing.md,
+                          borderBottomWidth: 2,
+                          borderBottomColor: active ? theme.colors.primary : "transparent",
+                        }}
                       >
-                        {t.label}
-                      </Text>
-                    </View>
-                  </TouchableRipple>
-                );
-              })}
+                        <Text
+                          variant="labelLarge"
+                          style={{ color: active ? theme.colors.onSurface : theme.colors.onSurfaceVariant }}
+                        >
+                          {t.label}
+                        </Text>
+                      </View>
+                    </TouchableRipple>
+                  );
+                })}
+              </View>
             </View>
 
             {/* TAB CONTENT (index 2) */}
             {/* minHeight keeps the content below the sticky tab bar at least a
                 screenful tall, so jumping to a tab can always scroll the tab
                 bar up to the top even when a tab's content is short. */}
-            <View style={{ paddingTop: Spacing.xl, minHeight: windowHeight }}>
+            <View style={{ paddingTop: Spacing.xl }}>
               {tab === "overview" ? (
                 <View style={{ gap: Spacing.xl }}>
                   {contacts.length > 0 && (
@@ -590,6 +600,8 @@ export default function Index() {
                         {location && (
                           <IconButton
                             icon="directions"
+                            containerColor={theme.colors.secondary}
+                            iconColor={theme.colors.onSecondary}
                             mode="contained"
                             onPress={() =>
                               openMap({

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -52,7 +52,7 @@ export function Button({
     }
     return {
       backgroundColor: "transparent",
-      textColor: theme.colors.primary,
+      textColor: "black"
     };
   };
 

--- a/components/CollapsibleText.tsx
+++ b/components/CollapsibleText.tsx
@@ -2,11 +2,13 @@ import { PropsWithChildren, useEffect, useState } from "react";
 
 import { Text, TouchableRipple } from "react-native-paper";
 import { ThemedText } from "./ThemedText";
-import { View } from "react-native";
-import { theme } from "@/assets/theme";
+import { StyleProp, View, ViewStyle } from "react-native";
 import { Spacing } from "@/constants/spacing";
 
-function CollapsibleText({ children }: PropsWithChildren) {
+function CollapsibleText({
+  children,
+  style,
+}: PropsWithChildren<{ style?: StyleProp<ViewStyle> }>) {
   const [isLongDescription, setIsLongDescription] = useState<
     undefined | boolean
   >(undefined);
@@ -15,17 +17,10 @@ function CollapsibleText({ children }: PropsWithChildren) {
     setIsLongDescription(undefined);
   }, []);
 
-  useEffect(() => {
-    console.log("isLongDescription", isLongDescription);
-    console.log("isundef", isLongDescription !== undefined);
-  }, [isLongDescription]);
-
   return (
     <TouchableRipple
-      style={{ padding: Spacing.sm }}
+      style={[{ padding: Spacing.sm }, style]}
       onLayout={(e) => {
-        console.log("height",e.nativeEvent.layout.height);
-
         if (
           isLongDescription === undefined &&
               e.nativeEvent.layout.height > 165
@@ -36,8 +31,6 @@ function CollapsibleText({ children }: PropsWithChildren) {
       onPress={
         isLongDescription !== undefined
           ? () => {
-            console.log("asd");
-
             setIsLongDescription(!isLongDescription);
           }
           : undefined

--- a/components/InfoLayer.tsx
+++ b/components/InfoLayer.tsx
@@ -7,7 +7,6 @@ import {
 import { RootState } from "@/redux/store";
 import {
   ActivityIndicator,
-  Button,
   Dialog,
   Portal,
   Snackbar,
@@ -18,6 +17,8 @@ import { useDispatch, useSelector } from "react-redux";
 import { ThemedText } from "./ThemedText";
 import { Spacing } from "@/constants/spacing";
 import { PatreonModal } from "./PatreonModal";
+import { Button } from "./Button";
+import { View } from "react-native";
 
 const InfoLayer = () => {
   const { dialogs, snacks, loading } = useSelector(
@@ -67,7 +68,7 @@ const InfoLayer = () => {
             <Dialog.Content>
               <Text variant="bodyMedium">{dialog?.text}</Text>
             </Dialog.Content>
-            <Dialog.Actions>
+            <View style={{flexDirection:"row",alignItems:"center",justifyContent:"flex-end",padding:Spacing.lg}}>
               {dialog?.dismissable && (
                 <Button onPress={cancelDialog}>Mégsem</Button>
               )}
@@ -75,10 +76,11 @@ const InfoLayer = () => {
                 mode="contained"
                 onPress={submitDialog}
                 loading={promiseInProgress}
+                            labelStyle={{ fontFamily: "RedHatText-Bold" }}
               >
                 {dialog?.submitText || "Kész"}
               </Button>
-            </Dialog.Actions>
+            </View>
           </Dialog>
         )}
         {snacks?.map((snack, ind) => (

--- a/components/MyAppBar.tsx
+++ b/components/MyAppBar.tsx
@@ -43,8 +43,12 @@ export const MyAppbar = ({ center, title, style }: { center?: ReactNode, title?:
       >
         <View style={{ width: 48 }} >
           {
-            navigation.canGoBack() && pathname !== "/home" && pathname !== "/" 
-            && <Appbar.BackAction onPress={navigation.goBack} />
+            pathname !== "/home" && pathname !== "/"
+            && <Appbar.BackAction
+              onPress={() =>
+                navigation.canGoBack() ? navigation.goBack() : router.push("/home")
+              }
+            />
           }
         </View>
         {center ? <View style={{ flex: 1 }}>{center}</View>

--- a/components/buziness/BuzinessEditScreen.tsx
+++ b/components/buziness/BuzinessEditScreen.tsx
@@ -4,11 +4,10 @@ import TagInput from "@/components/TagInput";
 import { useMyLocation } from "@/hooks/useMyLocation";
 import locationToCoords from "@/lib/functions/locationToCoords";
 import {
-  clearOptions,
+  addDialog,
+  addSnack,
   hideLoading,
-  setOptions,
   showLoading,
-  addSnack
 } from "@/redux/reducers/infoReducer";
 import { RootState } from "@/redux/store";
 import { CircleType, ImageDataType, UserState } from "@/redux/store.type";
@@ -17,44 +16,36 @@ import { router, Stack, useFocusEffect } from "expo-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ScrollView, View } from "react-native";
 import {
-  Card,
-  Divider,
-  Headline,
+  Dialog,
+  HelperText,
   Icon,
   IconButton,
-  List,
-  MD3DarkTheme,
   Modal,
   Portal,
   SegmentedButtons,
+  Surface,
+  Switch,
   Text,
   TextInput,
-  TouchableRipple,
 } from "react-native-paper";
 import { useDispatch, useSelector } from "react-redux";
 import { Marker } from "../mapView/mapView";
 import FiFeMap from "../mapView/FiFeMap";
 import { ThemedView } from "../ThemedView";
-import {
-  Dropdown,
-  DropdownInputProps,
-  Option,
-} from "react-native-paper-dropdown";
-import typeToIcon from "@/lib/functions/typeToIcon";
-import { ThemedText } from "../ThemedText";
 import BuzinessImageUpload, {
   BuzinessImageUploadHandle,
 } from "./BuzinessImageUpload";
 import getImagesUrlFromSupabase from "@/lib/functions/getImagesUrlFromSupabase";
-import { Image } from "expo-image";
 import NewMarkerIcon from "@/assets/images/newMarkerIcon";
 import BuzinessItem from "./BuzinessItem";
 import { Button } from "../Button";
 import ContactEditScreen from "./ContactEditScreen";
 import { PostgrestSingleResponse } from "@supabase/supabase-js";
 import { Tables } from "@/database.types";
-import { theme } from "@/assets/theme";
+import { useAppTheme } from "@/assets/theme";
 import { Spacing } from "@/constants/spacing";
+import { BorderRadius } from "@/constants/borderRadius";
+import SectionLabel from "./SectionLabel";
 
 interface NewBuzinessInterface {
   title: string;
@@ -65,12 +56,12 @@ interface BuzinessEditScreenProps {
 }
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
-// Default radius in km for location-based buziness
 const DEFAULT_RADIUS = 20;
 
 export default function BuzinessEditScreen({
   editId,
 }: BuzinessEditScreenProps) {
+  const theme = useAppTheme();
   const { uid }: UserState = useSelector((state: RootState) => state.user);
   const dispatch = useDispatch();
   const [categories, setCategories] = useState<string[]>([]);
@@ -78,18 +69,20 @@ export default function BuzinessEditScreen({
     title: "",
     description: "",
   });
-  const [myContacts, setMyContacts] = useState<Option[]>([]);
-  const [contacts, setContacts] = useState<Optional<Tables<"contacts">, "id">[]>([]);
+  const [contacts, setContacts] = useState<Optional<Tables<"contacts">, "id">[]>(
+    [],
+  );
   const [defaultContact, setDefaultContact] = useState<number | undefined>();
 
+  const [ingyen, setIngyen] = useState(false);
   const [images, setImages] = useState<ImageDataType[]>([]);
   const imagesUploadRef = useRef<BuzinessImageUploadHandle | null>(null);
   const contactEditRef = useRef<{
     saveContacts: () => Promise<
       | PostgrestSingleResponse<unknown>
       | {
-        error: string;
-      }
+          error: string;
+        }
       | undefined
     >;
     getContacts: () => Optional<Tables<"contacts">, "id">[];
@@ -98,55 +91,53 @@ export default function BuzinessEditScreen({
   const [circle, setCircle] = useState<CircleType | undefined>(undefined);
   const selectedLocation = circle?.location || myLocation?.coords;
   const [loading, setLoading] = useState(false);
-  const [contactsExpanded, setContactsExpanded] = useState(false);
 
   const [mapModalVisible, setMapModalVisible] = useState(false);
-  const [tutorialVisible, setTutorialVisible] = useState(true);
+  const [helpVisible, setHelpVisible] = useState(false);
 
   const title = [newBuziness.title, ...categories].join(" $ ");
+  const hasContact = contacts.some(
+    (c) => !!c && !!c.data && c.data.length > 0,
+  );
   const canSubmit = !!(
     newBuziness.title &&
-    categories &&
+    categories.length > 0 &&
     newBuziness.description &&
-    contacts.some((c) => !!c && !!c.data && c.data.length > 0)
+    hasContact
   );
-  useEffect(() => {
-    console.log("images", images);
-  }, [images]);
 
   const save = useCallback(async () => {
     setLoading(true);
     if (!uid) return;
 
-    // First save contacts
     const contactResponse = await contactEditRef.current?.saveContacts();
-    console.log("Contact save response:", contactResponse);
 
     if (contactResponse?.error) {
-      console.log("Error saving contacts:", contactResponse.error);
-      dispatch(addSnack({
-        title: "Hiba az elérhetőségek mentése során. Ellenőrizd a mezőket.",
-      }));
+      dispatch(
+        addSnack({
+          title:
+            "Hiba az elérhetőségek mentése során. Ellenőrizd a mezőket.",
+        }),
+      );
       setLoading(false);
       return;
     }
 
-    // Verify at least one contact exists
     const contactsCheck = await supabase
       .from("contacts")
       .select("id")
       .eq("author", uid);
 
     if (!contactsCheck.data || contactsCheck.data.length === 0) {
-      console.log("No contacts found for user");
-      dispatch(addSnack({
-        title: "Legalább egy elérhetőséget kötelező megadni a biznisz létrehozásához.",
-      }));
+      dispatch(
+        addSnack({
+          title:
+            "Legalább egy elérhetőséget kötelező megadni a biznisz létrehozásához.",
+        }),
+      );
       setLoading(false);
       return;
     }
-
-    console.log(selectedLocation);
 
     await supabase.functions
       .invoke("create-buziness", {
@@ -154,6 +145,7 @@ export default function BuzinessEditScreen({
           id: editId,
           ...newBuziness,
           title,
+          ingyen,
           author: uid,
           location: selectedLocation
             ? `POINT(${selectedLocation?.longitude} ${selectedLocation?.latitude})`
@@ -163,10 +155,10 @@ export default function BuzinessEditScreen({
       })
       .then(async (res) => {
         const buzinessId = editId ?? res.data?.id;
-        console.log(res, images.length, buzinessId);
         if (images.length && buzinessId) {
-          const newImages = await imagesUploadRef.current?.uploadImages(buzinessId);
-          console.log("uploadRes", newImages);
+          const newImages = await imagesUploadRef.current?.uploadImages(
+            buzinessId,
+          );
           if (uid && newImages)
             await supabase
               .from("buziness")
@@ -181,83 +173,58 @@ export default function BuzinessEditScreen({
                     }),
                   ) as string[],
               })
-              .eq("id", buzinessId)
-              .then((res) => {
-                console.log("images upsert", res);
-              });
-
-          //return images.filter((i, ind) => i && imagesRes?.[ind]?.error);
+              .eq("id", buzinessId);
         }
         setLoading(false);
         if (res.error) {
-          console.log(res.error);
-          dispatch(addSnack({
-            title: "Hiba történt a biznisz mentése során.",
-          }));
+          dispatch(
+            addSnack({ title: "Hiba történt a biznisz mentése során." }),
+          );
           return;
         }
-        console.log(res);
         router.navigate("/user");
       });
-  }, [defaultContact, dispatch, editId, images.length, newBuziness, selectedLocation, title, uid]);
+  }, [
+    defaultContact,
+    dispatch,
+    editId,
+    images.length,
+    ingyen,
+    newBuziness,
+    selectedLocation,
+    title,
+    uid,
+  ]);
 
   const saveRef = useRef(save);
-  useEffect(() => { saveRef.current = save; }, [save]);
-
   useEffect(() => {
-    if (circle) {
-      setMapModalVisible(false);
-    }
-  }, [circle]);
+    saveRef.current = save;
+  }, [save]);
 
-  // Function to reload contacts after saving
-  const reloadContacts = useCallback(() => {
-    if (uid) {
-      supabase
-        .from("contacts")
-        .select("*")
-        .eq("author", uid)
-        .then((res) => {
-          if (res.data) {
-            setContacts(res.data as Optional<Tables<"contacts">, "id">[]);
-            setMyContacts(
-              res.data.map((contact) => {
-                return {
-                  label: contact.data,
-                  value: contact.id.toString(),
-                };
-              }),
-            );
-          }
-        });
-    }
+  const loadContacts = useCallback(() => {
+    if (!uid) return;
+    supabase
+      .from("contacts")
+      .select("*")
+      .eq("author", uid)
+      .then((res) => {
+        if (res.data) {
+          setContacts(res.data as Optional<Tables<"contacts">, "id">[]);
+        }
+      });
   }, [uid]);
 
-  useEffect(() => {
+  const handleSavePress = useCallback(async () => {
     dispatch(
-      setOptions([
-        {
-          title: "Mentés",
-          icon: "content-save",
-          disabled: !canSubmit || loading,
-          onPress: async () => {
-            dispatch(
-              showLoading({
-                dismissable: false,
-                title: "Kérlek várj, amíg a bizniszed feltöltődik",
-              }),
-            );
-            await saveRef.current();
-            dispatch(hideLoading());
-            reloadContacts();
-          },
-        },
-      ]),
+      showLoading({
+        dismissable: false,
+        title: "Kérlek várj, amíg a bizniszed feltöltődik",
+      }),
     );
-    return () => {
-      dispatch(clearOptions());
-    };
-  }, [canSubmit, dispatch, save, loading, reloadContacts]);
+    await saveRef.current();
+    dispatch(hideLoading());
+    loadContacts();
+  }, [dispatch, loadContacts]);
 
   useFocusEffect(
     useCallback(() => {
@@ -280,7 +247,9 @@ export default function BuzinessEditScreen({
                 editingBuziness.title
                   .split(" $ ")
                   .slice(1)
+                  .filter(Boolean),
               );
+              setIngyen(!!editingBuziness.ingyen);
               if (editingBuziness.defaultContact)
                 setDefaultContact(editingBuziness.defaultContact);
               if (editingBuziness.images)
@@ -298,269 +267,258 @@ export default function BuzinessEditScreen({
             }
           });
       }
-      if (uid) {
-
-        supabase
-          .from("contacts")
-          .select("*")
-          .eq("author", uid)
-          .then((res) => {
-            if (res.data) {
-              setContacts(res.data as Optional<Tables<"contacts">, "id">[]);
-              setMyContacts(
-                res.data.map((contact) => {
-                  return {
-                    label: contact.data,
-                    value: contact.id.toString(),
-                  };
-                }),
-              );
-              // If no contacts exist, expand the contacts section by default
-              if (res.data.length === 0) {
-                setContactsExpanded(true);
-              }
-            }
-          });
-      }
-
-      return () => {
-        console.log("This route is now unfocused.");
-      };
-    }, [editId, navigation, uid]),
+      loadContacts();
+    }, [editId, uid, loadContacts]),
   );
+
+  const handleOpenDialog = () => {
+    dispatch(addDialog({
+      title: "Mihez értesz?",
+      text: `Ezen az oldalon fel tudsz venni egy új bizniszt a profilodba.
+A te bizniszeid azon hobbijaid, képességeid vagy szakmáid listája, amelyeket meg szeretnél osztani másokkal is.
+Ha, mondjuk, futószalagon gyártod a sütiket, és ezt felveszed a bizniszeid közé, a Biznisz oldalon megtalálható leszel a süti kulcsszóval.`,
+      onSubmit: ()=>{},
+      submitText: "Okés",
+    }));
+  };
+
+  const surfaceStyle = {
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.lg,
+    gap: Spacing.md,
+  };
+
   return (
     <>
-      {editId && <Stack.Screen options={{ title: "Biznisz szerkesztése" }} />}
+      <Stack.Screen
+        options={{ title: editId ? "Biznisz szerkesztése" : "Új Biznisz" }}
+      />
       <ThemedView style={{ flex: 1 }}>
-        <ScrollView style={{ flex: 1 }} contentContainerStyle={{}}>
-          {tutorialVisible && (
-            <Card
-              mode="elevated"
-              style={{ borderTopLeftRadius: 0, borderTopRightRadius: 0 }}
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{
+            paddingHorizontal: Spacing.md,
+            paddingTop: Spacing.lg,
+            paddingBottom: Spacing.xxl,
+            gap: Spacing.lg,
+          }}
+        >
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              gap: Spacing.sm,
+              paddingHorizontal: Spacing.xs,
+            }}
+          >
+            <Text
+              variant="bodyMedium"
+              style={{ flex: 1, color: theme.colors.onSurfaceVariant }}
             >
-              <Card.Title
-                title={"Mihez értesz?"}
-                right={() => (
-                  <IconButton
-                    icon="close"
-                    onPress={() => setTutorialVisible(false)}
-                  />
-                )}
+              Oszd meg, miben tudsz másoknak segíteni.
+            </Text>
+            <IconButton
+              icon="help-circle-outline"
+              size={22}
+              onPress={handleOpenDialog}
+              accessibilityLabel="Mi ez az oldal?"
+            />
+          </View>
+
+          <View style={{ gap: Spacing.sm }}>
+            <SectionLabel label="Alapadatok" />
+            <Surface elevation={1} style={surfaceStyle}>
+              <TextInput
+                mode="outlined"
+                label="Biznisz neve *"
+                value={newBuziness.title}
+                onChangeText={(t) =>
+                  setNewBuziness({ ...newBuziness, title: t })
+                }
               />
-              <Card.Content>
-                {tutorialVisible && (
-                  <Text>
-                    Ezen az oldalon fel tudsz venni egy új bizniszt a profilodba.
-                    {"\n"}A te bizniszeid azon hobbijaid, képességeid vagy
-                    szakmáid listája, amelyeket meg szeretnél osztani másokkal is.{" "}
-                    {"\n"}Ha, mondjuk, futószalagon gyártod a sütiket, és
-                    ezt felveszed a bizniszeid közé, a Biznisz oldalon
-                    megtalálható leszel a süti kulcsszóval.
-                  </Text>
-                )}
-              </Card.Content>
-            </Card>
-          )}
-          <View style={{}}>
-            <TextInput
-              placeholder="Bizniszem neve"
-              value={newBuziness.title}
-              onChangeText={(t) => setNewBuziness({ ...newBuziness, title: t })}
-            />
-            <TagInput
-              style={{marginVertical: Spacing.sm}}
-              placeholder="Kategóriák, nyomj entert a hozzáadásukhoz"
-              onChange={setCategories}
-              value={categories}
-            />
-            <TextInput
-              placeholder="Fejtsd ki bővebben"
-              value={newBuziness.description}
-              multiline
-              onChangeText={(t) =>
-                setNewBuziness({ ...newBuziness, description: t })
-              }
-            />
-            <Dropdown
-              label="Kiemelt elérhetőséged"
-              options={myContacts}
-              value={defaultContact?.toString() ?? ""}
-              CustomDropdownInput={({
-                placeholder,
-                selectedLabel,
-                label,
-                rightIcon,
-              }: DropdownInputProps) => (
-                <TextInput
-                  placeholder={placeholder}
-                  label={label}
-                  value={selectedLabel ?? ""}
-                  right={rightIcon}
-                />
-              )}
-              CustomDropdownItem={({
-                option,
-                value,
-                onSelect,
-                toggleMenu,
-                isLast,
-              }) => {
-                return (
-                  <>
-                    <TouchableRipple
-                      onPress={() => {
-                        onSelect?.(option.value);
-                        toggleMenu();
-                      }}
-                    >
-                      <Headline
-                        style={{
-                          color:
-                            value === option.value
-                              ? MD3DarkTheme.colors.onPrimary
-                              : MD3DarkTheme.colors.primary,
-                          alignItems: "center",
-                          display: "flex",
-                          padding: 8,
-                        }}
+              <TextInput
+                mode="outlined"
+                label="Leírás *"
+                value={newBuziness.description}
+                multiline
+                numberOfLines={4}
+                onChangeText={(t) =>
+                  setNewBuziness({ ...newBuziness, description: t })
+                }
+              />
+            </Surface>
+          </View>
+
+          <View style={{ gap: Spacing.sm }}>
+            <SectionLabel label="Kulcsszavak" required />
+            <Surface elevation={1} style={surfaceStyle}>
+              <TagInput
+                placeholder="Új kulcsszó…"
+                onChange={setCategories}
+                value={categories}
+              />
+              <HelperText type="info" visible style={{ paddingLeft: 0 }}>
+                Pl. süti, kerékpár, programozás
+              </HelperText>
+            </Surface>
+          </View>
+
+          <View style={{ gap: Spacing.sm }}>
+            <SectionLabel label="Elérhetőségek" required />
+            <Surface elevation={1} style={surfaceStyle}>
+              <Text
+                variant="bodyMedium"
+                style={{ color: theme.colors.onSurfaceVariant }}
+              >
+                Töltsd ki azt, ahol elérhetnek. A csillaggal jelölheted a
+                legfontosabbat.
+              </Text>
+              <ContactEditScreen
+                ref={contactEditRef}
+                onContactsChange={(newContacts) => setContacts(newContacts)}
+                defaultContactId={defaultContact}
+                onDefaultContactChange={setDefaultContact}
+                showFeaturedToggle
+              />
+            </Surface>
+            {!hasContact && (
+              <HelperText
+                type="error"
+                visible
+                style={{ paddingLeft: Spacing.xs }}
+              >
+                Legalább egy elérhetőség megadása kötelező.
+              </HelperText>
+            )}
+          </View>
+
+          <View style={{ gap: Spacing.sm }}>
+            <SectionLabel label="Hol érhető el a bizniszed?" />
+            <Surface elevation={1} style={surfaceStyle}>
+              <SegmentedButtons
+                value={!circle ? "net" : "map"}
+                onValueChange={(v) => {
+                  if (v === "net") setCircle(undefined);
+                  else setMapModalVisible(true);
+                }}
+                buttons={[
+                  { value: "net", label: "Bárhol", icon: "wifi" },
+                  { value: "map", label: "Térképen", icon: "map-marker" },
+                ]}
+              />
+              {circle ? (
+                <View
+                  style={{
+                    borderRadius: BorderRadius.md,
+                    overflow: "hidden",
+                    height: 200,
+                  }}
+                >
+                  <FiFeMap
+                    zoomControlEnabled={false}
+                    initialCamera={{
+                      center:
+                        selectedLocation || myLocation?.coords || undefined,
+                    }}
+                    style={{ width: "100%", height: 200 }}
+                    moveOnMarkerPress
+                  >
+                    {(!!selectedLocation || !!myLocation) && (
+                      <Marker
+                        coordinate={
+                          selectedLocation ||
+                          myLocation?.coords || {
+                            latitude: 47.4979,
+                            longitude: 19.0402,
+                          }
+                        }
+                        anchor={{ x: 0.5, y: 0.5 }}
                       >
-                        <Icon source={typeToIcon(option.label) || "dots-horizontal"} size={22} />
-                        <ThemedText style={{ marginLeft: 8 }}>
-                          {option.label}
-                        </ThemedText>
-                      </Headline>
-                    </TouchableRipple>
-                    {!isLast && <Divider />}
-                  </>
-                );
-              }}
-              hideMenuHeader
-              onSelect={(e) => {
-                setDefaultContact(Number(e));
-              }}
-            />
-            <List.Item
-              title="Elérhetőségek"
-              style={{ marginTop: 8 }}
-              description="Legalább egy elérhetőség megadása kötelező"
-              onPress={() => setContactsExpanded(!contactsExpanded)}
-              left={(props) => <List.Icon {...props} icon="contacts" />}
-              right={() =>
-                !contacts.some((c) => !!c && !!c.data && c.data.length > 0) ? (
-                  <View style={{ flexDirection: "row", alignItems: "center" }}>
-                    <Icon source="alert-circle" size={20} color={theme.colors.error} />
-                  </View>
-                ) : <List.Icon icon={contactsExpanded ? "chevron-up" : "chevron-down"} />
-              }
-            />
-            <View style={{ display: contactsExpanded ? "flex" : "none" }}>
-              <ContactEditScreen ref={contactEditRef} onContactsChange={(newContacts) => setContacts(newContacts)} style={{ padding: 16, paddingRight: 0, }} />
-            </View>
-            <Divider style={{ marginTop: 8, marginBottom: 8 }} />
-            <BuzinessImageUpload
-              images={images}
-              setImages={setImages}
-              buzinessId={editId}
-              ref={imagesUploadRef}
-            />
-            {(
+                        <NewMarkerIcon width={24} height={24} />
+                      </Marker>
+                    )}
+                  </FiFeMap>
+                </View>
+              ) : (
+                <Text
+                  variant="bodyMedium"
+                  style={{ color: theme.colors.onSurfaceVariant }}
+                >
+                  A bizniszed bárhonnan elérhető — nincs földrajzi helyhez
+                  kötve.
+                </Text>
+              )}
+              {circle && (
+                <Button
+                  mode="contained-tonal"
+                  onPress={() => setMapModalVisible(true)}
+                >
+                  Környék módosítása
+                </Button>
+              )}
+            </Surface>
+          </View>
+
+          <View style={{ gap: Spacing.sm }}>
+            <SectionLabel label="Képek" optional />
+            <Surface elevation={1} style={surfaceStyle}>
+              <BuzinessImageUpload
+                images={images}
+                setImages={setImages}
+                buzinessId={editId}
+                ref={imagesUploadRef}
+              />
+            </Surface>
+          </View>
+
+          <View style={{ gap: Spacing.sm }}>
+            <SectionLabel label="Beállítások" />
+            <Surface elevation={1} style={surfaceStyle}>
               <View
                 style={{
                   flexDirection: "row",
-                  flexWrap: "wrap",
-                  justifyContent: "space-between",
                   alignItems: "center",
-                  padding: 8,
+                  gap: Spacing.md,
                 }}
               >
-                <ThemedText>A bizniszed helyzete</ThemedText>
-
-                <SegmentedButtons
-                  value={!circle ? "net" : "map"}
-                  style={{ width: 300 }}
-                  onValueChange={
-                    (v) => {
-                      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-                      v == "net" ?
-                        setCircle(undefined) :
-                        setMapModalVisible(true);
-                    }}
-                  buttons={[
-                    {
-                      value: "net",
-                      label: "Bárhol",
-                      icon: "wifi"
-                    },
-                    {
-                      value: "map",
-                      label: "Térképen",
-                      icon: "map-marker"
-                    },
-                  ]}
+                <Icon
+                  source="charity"
+                  size={24}
+                  color={theme.colors.primary}
+                />
+                <View style={{ flex: 1, gap: 2 }}>
+                  <Text variant="bodyMedium">Ingyenes / önkéntes biznisz</Text>
+                  <Text
+                    variant="bodyMedium"
+                    style={{ color: theme.colors.onSurfaceVariant }}
+                  >
+                    Jelöld be, ha ingyenesen vagy önkéntesen végzed.
+                  </Text>
+                </View>
+                <Switch
+                  value={ingyen}
+                  onValueChange={setIngyen}
+                  color={theme.colors.nature}
                 />
               </View>
-            )}
-            <View style={{ minHeight: circle ? 300 : 100 }}>
-              {circle ? (
-                <FiFeMap
-                  zoomControlEnabled={false}
-                  initialCamera={{
-                    center: selectedLocation ||
-                      myLocation?.coords || undefined,
-                  }}
-                  style={{ width: "100%", height: 300 }}
-                  moveOnMarkerPress
-                >
-                  {(!!selectedLocation || !!myLocation) && (
-                    <Marker
-                      coordinate={
-                        selectedLocation ||
-                        myLocation?.coords || {
-                          latitude: 47.4979,
-                          longitude: 19.0402,
-                        }
-                      }
-                      anchor={{ x: 0.5, y: 0.5 }}
-                    >
-                      <NewMarkerIcon width={24} height={24} />
-                    </Marker>
-                  )}
-                </FiFeMap>
-              ) : (
-                <View style={{ alignItems: "center", gap: 8, padding: 16 }}>
-                  <Image
-                    style={{ width: 100, height: 100 }}
-                    source={require("@/assets/images/img-map.png")}
-                  />
-                  <ThemedText type="subtitle">
-                    Találjanak meg a helyiek
-                  </ThemedText>
-                  <Button
-                    onPress={() => setMapModalVisible(true)}
-                    mode={"contained-tonal"}
-                  >
-                    Válassz környéket
-                  </Button>
-                </View>
-              )}
-            </View>
+            </Surface>
           </View>
-          <ThemedView
-            type="default"
-            style={{
-              padding: 8,
-              bottom: 0,
-              width: "100%",
-              gap: 16
-            }}
-          >
-            <ThemedText>Így fog megjelenni a bizniszed:</ThemedText>
+
+          <View style={{ gap: Spacing.sm }}>
+            <SectionLabel label="Így fog megjelenni" />
             <BuzinessItem
+              preview
               data={{
                 id: editId || 0,
                 author: uid || "",
-                title: [newBuziness.title || "A biznisz címe", ...(categories.length ? categories : ["Egy kategória", "Egy másik kategória"])].join(" $ "),
-                description: newBuziness.description || "Hosszabb leírás hogy miről szól a bizniszed.",
+                title:
+                  (newBuziness.title || "A biznisz címe") +
+                  (categories.length
+                    ? " $ " + categories.join(" $ ")
+                    : " $ Egy kategória $ Egy másik kategória"),
+                description:
+                  newBuziness.description ||
+                  "Hosszabb leírás hogy miről szól a bizniszed.",
                 images: images,
                 location: circle
                   ? `POINT(${circle.location.longitude} ${circle.location.latitude})`
@@ -568,28 +526,43 @@ export default function BuzinessEditScreen({
                 recommendations: 0,
               }}
             />
-            <View style={{ alignItems: "flex-end" }}>
-              <Button mode="contained" onPress={async () => {
-                dispatch(showLoading({ dismissable: false, title: "Kérlek várj, amíg a bizniszed feltöltődik" }));
-                await saveRef.current();
-                dispatch(hideLoading());
-                reloadContacts();
-              }} disabled={!canSubmit || loading}>Mentés</Button>
-            </View>
-          </ThemedView>
+          </View>
         </ScrollView>
+
+        <Surface
+          elevation={2}
+          style={{
+            paddingHorizontal: Spacing.lg,
+            paddingVertical: Spacing.md,
+            borderTopWidth: 1,
+            borderTopColor: theme.colors.outlineVariant,
+            flexDirection: "row",
+          }}
+        >
+          <Button
+            mode="contained"
+            icon="check-bold"
+            disabled={!canSubmit || loading}
+            onPress={handleSavePress}
+            style={{ flex: 1, borderRadius: BorderRadius.lg }}
+            contentStyle={{ height: 56 }}
+            labelStyle={{ fontFamily: "RedHatText-Bold" }}
+          >
+            Mentés
+          </Button>
+        </Surface>
+
         <Portal>
           <Modal
             visible={mapModalVisible}
-            onDismiss={() => {
-              setMapModalVisible(false);
-            }}
+            onDismiss={() => setMapModalVisible(false)}
             style={{ alignItems: "center" }}
             contentContainerStyle={[
               {
                 width: "90%",
                 height: "90%",
-              }]}
+              },
+            ]}
             dismissableBackButton
           >
             <ThemedView style={containerStyle.containerStyle}>

--- a/components/buziness/ContactsCard.tsx
+++ b/components/buziness/ContactsCard.tsx
@@ -1,0 +1,97 @@
+import { useAppTheme } from "@/assets/theme";
+import { BorderRadius } from "@/constants/borderRadius";
+import { Spacing } from "@/constants/spacing";
+import { Tables } from "@/database.types";
+import getLinkForContact from "@/lib/functions/getLinkForContact";
+import typeToIcon from "@/lib/functions/typeToIcon";
+import typeToValueLabel from "@/lib/functions/typeToValueLabel";
+import { addSnack } from "@/redux/reducers/infoReducer";
+import * as Clipboard from "expo-clipboard";
+import React from "react";
+import { Linking, View } from "react-native";
+import { Icon, Surface, Text, TouchableRipple } from "react-native-paper";
+import { useDispatch } from "react-redux";
+
+interface ContactsCardProps {
+  contacts: Tables<"contacts">[];
+}
+
+export default function ContactsCard({ contacts }: ContactsCardProps) {
+  const theme = useAppTheme();
+  const dispatch = useDispatch();
+
+  return (
+    <Surface
+      style={{
+        borderRadius: BorderRadius.lg,
+        overflow: "hidden",
+        width: "100%",
+      }}
+      elevation={1}
+    >
+      {contacts.map((contact, index) => (
+        <React.Fragment key={contact.id}>
+          {index > 0 && (
+            <View
+              style={{
+                height: 1,
+                backgroundColor: theme.colors.outlineVariant,
+                marginHorizontal: Spacing.lg,
+              }}
+            />
+          )}
+          <TouchableRipple
+            onPress={() => {
+              const link = getLinkForContact(contact);
+              if (link) Linking.openURL(String(link));
+            }}
+            onLongPress={() => {
+              Clipboard.setStringAsync(contact.data).then(() => {
+                dispatch(addSnack({ title: "Vágólapra másolva!" }));
+              });
+            }}
+          >
+            <View
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                paddingVertical: Spacing.md,
+                paddingHorizontal: Spacing.lg,
+                gap: Spacing.md,
+              }}
+            >
+              <View
+                style={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: BorderRadius.full,
+                  backgroundColor: theme.colors.surfaceVariant,
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <Icon
+                  source={typeToIcon(contact.type)}
+                  size={20}
+                  color={theme.colors.primary}
+                />
+              </View>
+              <View style={{ flex: 1 }}>
+                <Text variant="bodyMedium" numberOfLines={1}>
+                  {contact.data}
+                </Text>
+                <Text
+                  variant="labelSmall"
+                  style={{ color: theme.colors.onSurfaceVariant }}
+                >
+                  {contact.title || typeToValueLabel(contact.type)}
+                </Text>
+              </View>
+              <Icon source="open-in-new" size={16} color={theme.colors.outline} />
+            </View>
+          </TouchableRipple>
+        </React.Fragment>
+      ))}
+    </Surface>
+  );
+}

--- a/components/comments/Comments.tsx
+++ b/components/comments/Comments.tsx
@@ -23,7 +23,6 @@ import {
 } from "react-native";
 import {
   ActivityIndicator,
-  Card,
   IconButton,
   Menu,
   Modal,
@@ -291,73 +290,74 @@ const Comments = ({ path, placeholder, limit = 10 }: CommentsProps) => {
       behavior={Platform.OS === "ios" ? "padding" : undefined}
     >
       {
-        <ScrollView
-          contentContainerStyle={{
-            flexDirection: "column",
-            paddingBottom: 10,
-            gap: Spacing.sm,
-            padding: Spacing.xs,
-          }}
-        >
+        <ScrollView contentContainerStyle={{ paddingBottom: 10 }}>
           {!!comments.length &&
             comments.map((comment, ind) => {
               return (
-                <Card key={"comment" + ind} contentStyle={{}}>
-                  <Card.Content
-                    style={[
-                      { flexDirection: "row", maxWidth: "100%", padding: 0 },
-                    ]}
-                  >
-                    <View style={{ flex: 1, padding: Spacing.sm }}>
-                      <View
-                        style={{ flexDirection: "row", alignItems: "center" }}
+                <View
+                  key={"comment" + ind}
+                  style={{
+                    flexDirection: "row",
+                    alignItems: "flex-start",
+                    gap: Spacing.sm,
+                    paddingVertical: Spacing.md,
+                    borderBottomWidth: ind < comments.length - 1 ? 1 : 0,
+                    borderBottomColor: theme.colors.outlineVariant,
+                  }}
+                >
+                  <View style={{ flex: 1, gap: 2 }}>
+                    <View
+                      style={{
+                        flexDirection: "row",
+                        alignItems: "baseline",
+                        gap: Spacing.sm,
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <Pressable
+                        onPress={() => {
+                          if (comment?.author)
+                            navigation.navigate({
+                              pathname: "/user/[uid]",
+                              params: { uid: comment.author },
+                            });
+                        }}
                       >
-                        <View style={{ flexDirection: "row", flex: 1 }}>
-                          <Pressable
-                            onPress={() => {
-                              if (comment?.author)
-                                navigation.navigate({
-                                  pathname: "/user/[uid]",
-                                  params: { uid: comment.author },
-                                });
-                            }}
-                          >
-                            <ThemedText style={{ fontWeight: "bold" }}>
-                              {comment?.profiles?.full_name ?? "Törölt felhasználó"}
-                            </ThemedText>
-                          </Pressable>
-                          <ThemedText style={{ marginLeft: Spacing.sm }}>
-                            {elapsedTime(comment.created_at)}
-                          </ThemedText>
-                        </View>
-                      </View>
-                      <UrlText text={comment.text} />
-                    </View>
-                    {comment.image && (
-                      <Pressable onPress={() => setSelectedComment(comment)}>
-                        <SupabaseImage
-                          bucket="comments"
-                          path={comment.image}
-                          style={{
-                            width: 100,
-                            height: 100,
-                            borderTopRightRadius: BorderRadius.lg,
-                            borderBottomRightRadius: BorderRadius.lg,
-                          }}
-                        />
+                        <ThemedText style={{ fontWeight: "bold", fontSize: 14 }}>
+                          {comment?.profiles?.full_name ?? "Törölt felhasználó"}
+                        </ThemedText>
                       </Pressable>
-                    )}
-                    {uid && (
-                      <IconButton
-                        icon="dots-vertical"
-                        onPress={(e) => showCommentMenu(e, comment)}
-                        size={18}
-                        iconColor={comment.image ? "white" : theme.colors.onSurface}
-                        style={{ margin: 0, position: "absolute", right: 0 }}
+                      <ThemedText
+                        style={{ color: theme.colors.onSurfaceVariant, fontSize: 12 }}
+                      >
+                        {elapsedTime(comment.created_at)}
+                      </ThemedText>
+                    </View>
+                    <UrlText text={comment.text} style={{ fontSize: 15, lineHeight: 22 }} />
+                  </View>
+                  {comment.image && (
+                    <Pressable onPress={() => setSelectedComment(comment)}>
+                      <SupabaseImage
+                        bucket="comments"
+                        path={comment.image}
+                        style={{
+                          width: 64,
+                          height: 64,
+                          borderRadius: BorderRadius.md,
+                        }}
                       />
-                    )}
-                  </Card.Content>
-                </Card>
+                    </Pressable>
+                  )}
+                  {uid && (
+                    <IconButton
+                      icon="dots-vertical"
+                      onPress={(e) => showCommentMenu(e, comment)}
+                      size={18}
+                      iconColor={theme.colors.onSurfaceVariant}
+                      style={{ margin: 0 }}
+                    />
+                  )}
+                </View>
               );
             })}
         </ScrollView>

--- a/components/comments/Comments.tsx
+++ b/components/comments/Comments.tsx
@@ -11,14 +11,11 @@ import { CommentsState, UserState } from "@/redux/store.type";
 import { supabase } from "@/lib/supabase/supabase";
 import * as ExpoImagePicker from "expo-image-picker";
 import { router } from "expo-router";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   GestureResponderEvent,
   ImageBackground,
-  KeyboardAvoidingView,
-  Platform,
   Pressable,
-  ScrollView,
   View,
 } from "react-native";
 import {
@@ -39,7 +36,7 @@ import { addSnack } from "@/redux/reducers/infoReducer";
 import { Spacing } from "@/constants/spacing";
 import { BorderRadius } from "@/constants/borderRadius";
 
-const Comments = ({ path, placeholder, limit = 10 }: CommentsProps) => {
+const Comments = ({ path, placeholder, limit = 10, style }: CommentsProps) => {
   const dispatch = useDispatch();
   const navigation = router;
   const theme = useTheme();
@@ -65,10 +62,12 @@ const Comments = ({ path, placeholder, limit = 10 }: CommentsProps) => {
 
   const [selectedComment, setSelectedComment] = useState<Comment | null>(null);
 
+  const mountId = useRef(Date.now()).current;
+
   useEffect(() => {
     dispatch(clearComments());
 
-    const channel = supabase.channel(path);
+    const channel = supabase.channel(`${path}:${mountId}`);
 
     const getMessages = async () => {
       const { data, error } = await supabase
@@ -178,9 +177,18 @@ const Comments = ({ path, placeholder, limit = 10 }: CommentsProps) => {
             return;
           }
 
-          if (image && data && data.length > 0) {
-            await uploadImage(uid + "/" + path, data[0].id);
-            setImage(null);
+          if (data && data.length > 0) {
+            dispatch(
+              addComment({
+                ...data[0],
+                profiles: { full_name: author },
+              }),
+            );
+
+            if (image) {
+              await uploadImage(uid + "/" + path, data[0].id);
+              setImage(null);
+            }
           }
 
           setText("");
@@ -285,12 +293,11 @@ const Comments = ({ path, placeholder, limit = 10 }: CommentsProps) => {
   };
 
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    <View
+      style={[{ flex: 1 }, style]}
     >
       {
-        <ScrollView contentContainerStyle={{ paddingBottom: 10 }}>
+        <View style={{ paddingBottom: 10, flex:1, minHeight: 200 }}>
           {!!comments.length &&
             comments.map((comment, ind) => {
               return (
@@ -360,14 +367,14 @@ const Comments = ({ path, placeholder, limit = 10 }: CommentsProps) => {
                 </View>
               );
             })}
-        </ScrollView>
+        </View>
       }
       {downloading && !comments.length ? (
         <ActivityIndicator />
       ) : (
         !comments?.length && (
-          <ThemedText style={{ padding: Spacing.xl }}>
-            Még nem érkezett komment
+          <ThemedText style={{ padding: Spacing.xl, textAlign:"center" }}>
+            Még nem érkezett vélemény
           </ThemedText>
         )
       )}
@@ -468,7 +475,7 @@ const Comments = ({ path, placeholder, limit = 10 }: CommentsProps) => {
           </Modal>
         </Portal>
       )}
-    </KeyboardAvoidingView>
+    </View>
   );
 };
 

--- a/components/comments/UrlText.tsx
+++ b/components/comments/UrlText.tsx
@@ -1,8 +1,14 @@
-import { Linking, Pressable, Text } from "react-native";
+import { Linking, Pressable, StyleProp, Text, TextStyle } from "react-native";
 import { useAppTheme } from "@/assets/theme";
 import { ThemedText } from "../ThemedText";
 
-const UrlText = ({ text = "" }: { text: string }) => {
+const UrlText = ({
+  text = "",
+  style,
+}: {
+  text: string;
+  style?: StyleProp<TextStyle>;
+}) => {
   const theme = useAppTheme();
 
   // Matches URLs (must start with http/https or www) and phone numbers (7+ digits)
@@ -31,7 +37,7 @@ const UrlText = ({ text = "" }: { text: string }) => {
 
     parts.push(
       <Pressable key={`l-${index}`} onPress={() => Linking.openURL(href)}>
-        <ThemedText style={{ color: theme.colors.secondary }}>{matched}</ThemedText>
+        <ThemedText style={[{ color: theme.colors.secondary }, style]}>{matched}</ThemedText>
       </Pressable>,
     );
 
@@ -42,7 +48,7 @@ const UrlText = ({ text = "" }: { text: string }) => {
     parts.push(<Text key={`t-${lastIndex}`}>{text.slice(lastIndex)}</Text>);
   }
 
-  return <ThemedText>{parts}</ThemedText>;
+  return <ThemedText style={style}>{parts}</ThemedText>;
 };
 
 export default UrlText;

--- a/components/comments/comments.types.ts
+++ b/components/comments/comments.types.ts
@@ -1,8 +1,10 @@
+import { StyleProp, ViewStyle } from "react-native";
 import { Tables } from "./../../database.types";
 export interface CommentsProps {
   path: string;
   placeholder: string;
   limit?: number;
+  style?: StyleProp<ViewStyle>;
 }
 
 export interface Comment extends Tables<"comments"> {

--- a/components/navigation/BottomNavigation.tsx
+++ b/components/navigation/BottomNavigation.tsx
@@ -1,4 +1,4 @@
-import { router, useSegments } from "expo-router";
+import { Route, router, useGlobalSearchParams, useSegments } from "expo-router";
 import { useRef, useCallback } from "react";
 import { StyleSheet, View } from "react-native";
 import { Badge, Icon, TouchableRipple } from "react-native-paper";
@@ -12,19 +12,31 @@ import Measure from "../tutorial/Measure";
 import { ThemedView } from "../ThemedView";
 const BottomNavigation = () => {
   const segment = useSegments();
+  const globalParams = useGlobalSearchParams();
   const { functions } = useSelector((state: RootState) => state.tutorial);
+  const { uid } = useSelector((state: RootState) => state.user);
 
   const bizniszActive = segment[0]?.includes("biznisz");
   const profilActive = segment[0]?.includes("user");
   const homeActive = segment[0]?.includes("home");
   const lastNavTime = useRef(0);
 
-  const navigateTo = useCallback((path: "/biznisz" | "/home" | "/user") => {
+  const navigateTo = useCallback((path: Route, params?: Record<string,string>) => {
     const now = Date.now();
     if (now - lastNavTime.current < 300) return;
+
+    if (params?.uid) {
+      // Profile tab: skip only if already viewing own profile
+      const alreadyOnMyProfile = segment[0] === "user" && globalParams.uid === uid;
+      if (alreadyOnMyProfile) return;
+    } else {
+      // Other tabs: skip if already on the same segment
+      if (segment[0] && path.includes(segment[0])) return;
+    }
+
     lastNavTime.current = now;
-    router.navigate(path);
-  }, []);
+    router.navigate(path, params);
+  }, [segment, uid, globalParams]);
 
   return (
     <ThemedView style={{ flexDirection: "row", backgroundColor: theme.colors.elevation.level0 }}>
@@ -60,7 +72,7 @@ const BottomNavigation = () => {
         </TouchableRipple>
       </Measure>
       <Measure name="user">
-        <TouchableRipple style={{ ...styles.button }} onPress={() => navigateTo("/user")}>
+        <TouchableRipple style={{ ...styles.button }} onPress={() => navigateTo("/user",{uid:uid!})}>
           <View style={{ alignItems: "center" }}>
             <Icon
               source={profilActive ? "account" : "account-outline"}

--- a/components/navigation/BottomNavigation.tsx
+++ b/components/navigation/BottomNavigation.tsx
@@ -31,7 +31,7 @@ const BottomNavigation = () => {
       if (alreadyOnMyProfile) return;
     } else {
       // Other tabs: skip if already on the same segment
-      if (segment[0] && path.includes(segment[0])) return;
+      if (segment[0] && path == segment[0]) return;
     }
 
     lastNavTime.current = now;

--- a/components/user/UserPage.tsx
+++ b/components/user/UserPage.tsx
@@ -6,9 +6,7 @@ import RecommendationsModal from "@/components/user/RecommendationsModal";
 import ReportProfileModal from "@/components/user/ReportProfileModal";
 import { Tables } from "@/database.types";
 import elapsedTime from "@/lib/functions/elapsedTime";
-import getLinkForContact from "@/lib/functions/getLinkForContact";
-import typeToIcon from "@/lib/functions/typeToIcon";
-import typeToValueLabel from "@/lib/functions/typeToValueLabel";
+import ContactsCard from "@/components/buziness/ContactsCard";
 import {
   clearBuziness,
   clearBuzinessSearchParams,
@@ -27,8 +25,8 @@ import {
   useFocusEffect,
   useGlobalSearchParams,
 } from "expo-router";
-import React, { useCallback, useState } from "react";
-import { Linking, ScrollView, View } from "react-native";
+import { useCallback, useState } from "react";
+import { ScrollView, View } from "react-native";
 import {
   Badge,
   Button,
@@ -294,63 +292,7 @@ export default function UserPage() {
               {contacts.length > 0 && (
                 <View style={{ width: "100%", gap: Spacing.sm }}>
                   <SectionLabel label="Elérhetőségek" />
-                  <Surface
-                    style={{
-                      borderRadius: BorderRadius.lg,
-                      overflow: "hidden",
-                      width: "100%",
-                    }}
-                    elevation={1}
-                  >
-                    {contacts.map((contact, index) => (
-                      <React.Fragment key={contact.id}>
-                        {index > 0 && (
-                          <View style={{
-                            height: 1,
-                            backgroundColor: theme.colors.outlineVariant,
-                            marginHorizontal: Spacing.lg,
-                          }} />
-                        )}
-                        <TouchableRipple
-                          onPress={() => {
-                            const link = getLinkForContact(contact);
-                            if (link) Linking.openURL(String(link));
-                          }}
-                          onLongPress={() => {
-                            Clipboard.setStringAsync(contact.data).then(() => {
-                              dispatch(addSnack({ title: "Vágólapra másolva!" }));
-                            });
-                          }}
-                        >
-                          <View style={{
-                            flexDirection: "row",
-                            alignItems: "center",
-                            paddingVertical: Spacing.md,
-                            paddingHorizontal: Spacing.lg,
-                            gap: Spacing.md,
-                          }}>
-                            <View style={{
-                              width: 40,
-                              height: 40,
-                              borderRadius: BorderRadius.full,
-                              backgroundColor: theme.colors.surfaceVariant,
-                              alignItems: "center",
-                              justifyContent: "center",
-                            }}>
-                              <Icon source={typeToIcon(contact.type)} size={20} color={theme.colors.primary} />
-                            </View>
-                            <View style={{ flex: 1 }}>
-                              <Text variant="bodyMedium" numberOfLines={1}>{contact.data}</Text>
-                              <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant }}>
-                                {contact.title || typeToValueLabel(contact.type)}
-                              </Text>
-                            </View>
-                            <Icon source="open-in-new" size={16} color={theme.colors.outline} />
-                          </View>
-                        </TouchableRipple>
-                      </React.Fragment>
-                    ))}
-                  </Surface>
+                  <ContactsCard contacts={contacts} />
                 </View>
               )}
               {myProfile && contacts.length === 0 && (

--- a/hooks/useMyLocation.ts
+++ b/hooks/useMyLocation.ts
@@ -16,10 +16,13 @@ export function useMyLocation() {
 
   const myLocation = useMemo(() => {
     if (!userData?.location) return null;
+    const lat = userData.location.lat;
+    const lng = userData.location.lng;
+    if (typeof lat !== "number" || typeof lng !== "number" || isNaN(lat) || isNaN(lng)) return null;
     return {
       coords: {
-        latitude: userData.location.lat,
-        longitude: userData.location.lng,
+        latitude: lat,
+        longitude: lng,
       },
     };
   }, [userData?.location]);

--- a/lib/auth/fetchUserProfile.ts
+++ b/lib/auth/fetchUserProfile.ts
@@ -22,7 +22,7 @@ export async function fetchUserProfile(user: User, dispatch: Dispatch) {
     ? (() => {
         const match = myLoc.location_wkt.match(/POINT\(([\d.-]+) ([\d.-]+)\)/);
         return match
-          ? { location: { lng: parseFloat(match[1]), lat: parseFloat(match[2]) }, radius: myLoc.location_radius_m ?? 0 }
+          ? { lat: parseFloat(match[2]), lng: parseFloat(match[1]), radius: myLoc.location_radius_m ?? 0 }
           : undefined;
       })()
     : undefined;

--- a/lib/functions/getDistance.ts
+++ b/lib/functions/getDistance.ts
@@ -1,0 +1,25 @@
+/**
+ * Haversine distance between two coordinates, in meters.
+ */
+const getDistance = (
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number,
+): number => {
+  const R = 6371000; // Earth radius in meters
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) *
+      Math.cos(toRad(lat2)) *
+      Math.sin(dLon / 2) *
+      Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+};
+
+export default getDistance;

--- a/lib/supabase/RecommendBuzinessButton.tsx
+++ b/lib/supabase/RecommendBuzinessButton.tsx
@@ -13,6 +13,8 @@ interface RecommendBuzinessButtonProps {
   recommended?: boolean;
   setRecommended: React.Dispatch<React.SetStateAction<boolean>>;
   style?: any;
+  /** Button mode when NOT yet recommended. Defaults to "contained". */
+  mode?: React.ComponentProps<typeof Button>["mode"];
 }
 
 export const RecommendBuzinessButton = ({
@@ -20,6 +22,7 @@ export const RecommendBuzinessButton = ({
   recommended,
   setRecommended,
   style,
+  mode = "contained",
 }: RecommendBuzinessButtonProps) => {
   const { uid: myUid }: UserState = useSelector(
     (state: RootState) => state.user,
@@ -87,7 +90,7 @@ export const RecommendBuzinessButton = ({
     <Button
       onPress={toggleRecommendation}
       style={style}
-      mode={!recommended ? "contained" : "contained-tonal"}
+      mode={!recommended ? mode : "contained-tonal"}
       loading={loading}
     >
       {recommended ? "Már ajánlottam." : "Ajánlom"}

--- a/redux/reducers/commentsReducer.ts
+++ b/redux/reducers/commentsReducer.ts
@@ -11,7 +11,9 @@ const commentsReducer = createSlice({
   name: "comments",
   reducers: {
     addComment: (state, action: PayloadAction<Comment>) => {
-      state.comments.unshift(action.payload);
+      if (!state.comments.some((c) => c.id === action.payload.id)) {
+        state.comments.unshift(action.payload);
+      }
     },
     addComments: (state, action: PayloadAction<Comment[]>) => {
       state.comments = action.payload;


### PR DESCRIPTION
## Summary
Restructures the biznisz detail page (`app/biznisz/[id].tsx`) into a hero + sticky-tab layout, and pulls shared pieces into reusable components.

- **Hero / stats / tab layout** — title, chips, byline, description, a stats card (Ajánlás / Vélemény / Távolság-or-Kora), primary CTA + recommend/save actions, an image carousel, and sticky **Áttekintés / Vélemények** tabs.
- **`ContactsCard`** extracted from `UserPage` and now shared by both the user page and the biznisz page (replaces the old `ContactList` usage on the detail page).
- **Style/prop hooks** added to shared components: `CollapsibleText` and `UrlText` accept an optional `style`; `RecommendBuzinessButton` accepts a `mode`.
- **Comments** rows restyled from `Card` to plain bordered rows.
- New helpers: `getDistance` (haversine, meters) used for the Távolság stat.
- `MyAppBar` back action falls back to `/home` when there's no navigation history.

## Cleanups (from a tidy-diff pass)
- Hoisted the per-render `Divider` to a module-scope `StatDivider` (was a new component identity each render → remount risk).
- Extracted a `StatItem` component to collapse the 3–4 near-identical stat blocks.
- Dropped the dangling bottom border under the last comment.
- `RecommendBuzinessButton`'s `mode` now derives from Paper's `Button` props instead of a hand-listed union.

## Verification
- `tsc --noEmit`: 103 pre-existing errors before and after — **no net new type errors**.
- Manual smoke test recommended on the stats card: confirm the three tap actions (Ajánlás → modal, Vélemény → reviews tab, Távolság → map), dividers between stats only, and that Kora is not tappable. Also confirm no trailing border under the last comment.

## Notes
- `buziness.defaultContact` is an FK to a single contact (drives the CTA); the separate by-author contacts query drives `ContactsCard` — these fetch different data and are both intentional.