### PR TITLE
Refactor home screen: extract FiFe Radar and add nearby businesses

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -186,8 +186,16 @@ function RootContent() {
               <Stack.Screen name="index" />
               <Stack.Protected guard={!!uid}>
                 <Stack.Screen
+                  name="me"
+                  options={{ header: () => <HomeHeader /> }}
+                />
+                <Stack.Screen
                   name="home"
                   options={{ header: () => <HomeHeader /> }}
+                />
+                <Stack.Screen
+                  name="fifeRadar"
+                  options={{ title: "FiFe Radar" }}
                 />
                 <Stack.Screen
                   name="biznisz/index"

--- a/app/csatlakozom/email-regisztracio.tsx
+++ b/app/csatlakozom/email-regisztracio.tsx
@@ -126,7 +126,7 @@ export default function Index() {
           dispatch(login(signInResponse.data.user.id));
           dispatch(setUserData(signInResponse.data.user));
           dispatch(addSnack({ title: "Bejelentkeztél!" }));
-          router.navigate("/home");
+          router.navigate("/me");
         }
       }
     }

--- a/app/fifeRadar.tsx
+++ b/app/fifeRadar.tsx
@@ -1,0 +1,100 @@
+import { theme } from "@/assets/theme";
+import { UsersList } from "@/components/user/UsersList";
+import { Spacing } from "@/constants/spacing";
+import MapSelector from "@/components/MapSelector/MapSelector";
+import { ThemedText } from "@/components/ThemedText";
+import { ThemedView } from "@/components/ThemedView";
+import {
+  storeUserSearchParams
+} from "@/redux/reducers/usersReducer";
+import { RootState } from "@/redux/store";
+import { useFocusEffect } from "expo-router";
+import { useCallback, useEffect, useState } from "react";
+import { View } from "react-native";
+import style from "@/components/styles";
+import {
+  Icon, Modal,
+  Portal
+} from "react-native-paper";
+import { useDispatch, useSelector } from "react-redux";
+import { Button } from "@/components/Button";
+import { useFifeSearch } from "@/hooks/useFifeSearch";
+
+export default function FifeRadarScreen() {
+  const { uid } = useSelector((state: RootState) => state.user);
+  const { userSearchParams } = useSelector(
+    (state: RootState) => state.users,
+  );
+  const searchCircle = userSearchParams?.searchCircle;
+  const dispatch = useDispatch();
+
+  const [locationMenuVisible, setLocationMenuVisible] = useState(false);
+  const { fetch, data, fetchNextPage, hasMore, error } = useFifeSearch();
+
+  useEffect(() => {
+    fetch();
+  }, [searchCircle]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (data.length === 0) {
+        fetch();
+      }
+    }, [data.length, fetch]),
+  );
+
+  return (
+    <>
+      {uid && (
+        <ThemedView style={{ flex: 1, zIndex: 100 }} type="default">
+          <ThemedView type="card" style={{ paddingHorizontal: Spacing.lg, paddingTop: 0, paddingBottom: Spacing.sm, flexDirection: "row", alignItems: "flex-end", justifyContent: "space-between" }}>
+            <View style={{ flexDirection: "row", alignItems: "flex-end", gap: Spacing.xs }}>
+              <ThemedText variant="labelLarge" type="bold" style={{ color: theme.colors.secondary }}>FiFe Radar</ThemedText>
+              <Icon size={18} color={theme.colors.secondary} source="wifi" />
+            </View>
+            <Button
+              icon={searchCircle ? "map-marker" : "map-marker-outline"}
+              mode="text"
+              labelStyle={{marginVertical: Spacing.xs}}
+              onPress={() => setLocationMenuVisible(true)}
+            >Hol keresel?</Button>
+          </ThemedView>
+          <UsersList load={fetchNextPage} canLoadMore={hasMore} data={data} error={error}/>
+          <Portal>
+            <Modal
+              visible={locationMenuVisible}
+              onDismiss={() => {
+                setLocationMenuVisible(false);
+              }}
+              style={{ alignItems: "center" }}
+              contentContainerStyle={[
+                {
+                  width: "90%",
+                  height: "90%",
+                },
+              ]}
+            >
+              <ThemedView style={style.containerStyle}>
+                <MapSelector
+                  data={searchCircle}
+                  setData={(sC) => {
+                    if (
+                      (sC && "location" in sC && "radius" in sC) ||
+                    sC == undefined
+                    ) {
+                      dispatch(storeUserSearchParams({ searchCircle: sC }));
+                      setLocationMenuVisible(false);
+                    }
+                  }}
+                  searchEnabled
+                  markerOnly
+                  setOpen={setLocationMenuVisible}
+                />
+              </ThemedView>
+            </Modal>
+          </Portal>
+        </ThemedView>
+      )}
+    </>
+  );
+}

--- a/app/home.tsx
+++ b/app/home.tsx
@@ -1,114 +1,92 @@
 import { theme } from "@/assets/theme";
-import { UsersList } from "@/components/user/UsersList";
-import { Spacing } from "@/constants/spacing";
-import MapSelector from "@/components/MapSelector/MapSelector";
+import BuzinessItem from "@/components/buziness/BuzinessItem";
+import { FiFeRadar } from "@/components/user/FiFeRadar";
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
-import EmotionCheckCard from "@/components/EmotionCheckCard";
-import {
-  storeUserSearchParams
-} from "@/redux/reducers/usersReducer";
+import { Spacing } from "@/constants/spacing";
 import { viewFunction } from "@/redux/reducers/tutorialReducer";
 import { RootState } from "@/redux/store";
 import { useFocusEffect } from "expo-router";
-import { useCallback, useEffect, useState } from "react";
-import { View } from "react-native";
-import style from "@/components/styles";
-import {
-  Icon, Modal,
-  Portal
-} from "react-native-paper";
+import { useCallback, useEffect } from "react";
+import { ScrollView, View } from "react-native";
+import { ActivityIndicator, Icon } from "react-native-paper";
 import { useDispatch, useSelector } from "react-redux";
-import WhatToDo from "@/components/WhatToDo";
-import { Button } from "@/components/Button";
 import { useFifeSearch } from "@/hooks/useFifeSearch";
-import { useProfileSearch } from "@/hooks/useProfileSearch";
+import { useNearbyBuzinesses } from "@/hooks/useNearbyBuzinesses";
 
 export default function Index() {
   const { uid } = useSelector((state: RootState) => state.user);
-  const { userSearchParams } = useSelector(
-    (state: RootState) => state.users,
+  const searchCircle = useSelector(
+    (state: RootState) => state.users.userSearchParams?.searchCircle,
   );
-  const searchCircle = userSearchParams?.searchCircle;
   const dispatch = useDispatch();
 
-  const [locationMenuVisible, setLocationMenuVisible] = useState(false);
-  const [whatVisible, setWhatVisible] = useState(false);
-  const { fetch, data, fetchNextPage, hasMore, error } = useFifeSearch();
-  const { results: newestUsers, search: fetchNewest } = useProfileSearch();
-
+  const { fetch, data, fetchNextPage, hasMore, error, loading } = useFifeSearch();
+  const {
+    data: nearbyBuzinesses,
+    fetch: fetchNearby,
+    loading: buzinessesLoading,
+    error: buzinessError,
+  } = useNearbyBuzinesses();
 
   useEffect(() => {
     fetch();
   }, [searchCircle]);
-
 
   useFocusEffect(
     useCallback(() => {
       if (data.length === 0) {
         fetch();
       }
-      if (newestUsers.length === 0) {
-        fetchNewest();
+      if (nearbyBuzinesses.length === 0) {
+        fetchNearby();
       }
       if (uid) dispatch(viewFunction({ key: "homePage", uid }));
-    }, [data.length, newestUsers.length, uid, dispatch, fetch, fetchNewest]),
+    }, [data.length, nearbyBuzinesses.length, uid, dispatch, fetch, fetchNearby]),
   );
 
+  if (!uid) return null;
   return (
-    <>
-      {uid && (
-        <ThemedView style={{ flex: 1, zIndex: 100 }} type="default">
-          <ThemedView type="card" style={{ paddingHorizontal: Spacing.lg, paddingTop: 0, paddingBottom: Spacing.sm, flexDirection: "row", alignItems: "flex-end", justifyContent: "space-between" }}>
-            <View style={{ flexDirection: "row", alignItems: "flex-end", gap: Spacing.xs }}>
-              <ThemedText variant="labelLarge" type="bold" style={{ color: theme.colors.secondary }}>Fife Radar</ThemedText>
-              <Icon size={18} color={theme.colors.secondary} source="wifi" />
-            </View>
-            <Button
-              icon={searchCircle ? "map-marker" : "map-marker-outline"}
-              mode="text"
-              labelStyle={{marginVertical: Spacing.xs}}
-              onPress={() => setLocationMenuVisible(true)}
-            >Hol keresel?</Button>
-          </ThemedView>
-          <EmotionCheckCard />
-          <UsersList load={fetchNextPage} canLoadMore={hasMore} data={data} error={error}/>
-          <WhatToDo visible={whatVisible} onDismiss={() => setWhatVisible(false)} />
-          <Portal>
-            <Modal
-              visible={locationMenuVisible}
-              onDismiss={() => {
-                setLocationMenuVisible(false);
-              }}
-              style={{ alignItems: "center" }}
-              contentContainerStyle={[
-                {
-                  width: "90%",
-                  height: "90%",
-                },
-              ]}
-            >
-              <ThemedView style={style.containerStyle}>
-                <MapSelector
-                  data={searchCircle}
-                  setData={(sC) => {
-                    if (
-                      (sC && "location" in sC && "radius" in sC) ||
-                    sC == undefined
-                    ) {
-                      dispatch(storeUserSearchParams({ searchCircle: sC }));
-                      setLocationMenuVisible(false);
-                    }
-                  }}
-                  searchEnabled
-                  markerOnly
-                  setOpen={setLocationMenuVisible}
-                />
-              </ThemedView>
-            </Modal>
-          </Portal>
+    <ThemedView style={{ flex: 1 }} type="default">
+      <ScrollView contentContainerStyle={{ paddingBottom: Spacing.xl }}>
+        <FiFeRadar
+          data={data}
+          load={fetchNextPage}
+          canLoadMore={hasMore}
+          loading={loading}
+          error={error}
+        />
+        <ThemedView
+          type="card"
+          style={{
+            paddingHorizontal: Spacing.lg,
+            paddingVertical: Spacing.sm,
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <View style={{ flexDirection: "row", alignItems: "flex-end", gap: Spacing.xs }}>
+            <ThemedText variant="labelLarge" type="bold" style={{ color: theme.colors.secondary }}>
+              Közeli Bizniszek
+            </ThemedText>
+            <Icon size={18} color={theme.colors.secondary} source="map-marker" />
+          </View>
         </ThemedView>
-      )}
-    </>
+        {!!buzinessError && (
+          <ThemedView style={{ margin: 6, alignItems: "center" }} type="error">
+            <ThemedText type="error">{buzinessError}</ThemedText>
+          </ThemedView>
+        )}
+        <View style={{ gap: Spacing.sm, paddingHorizontal: Spacing.md, paddingVertical: Spacing.sm }}>
+          {nearbyBuzinesses.map((buziness) => (
+            <BuzinessItem key={buziness.id} data={buziness} />
+          ))}
+          {buzinessesLoading && !nearbyBuzinesses.length && (
+            <ActivityIndicator style={{ padding: Spacing.lg }} />
+          )}
+        </View>
+      </ScrollView>
+    </ThemedView>
   );
 }

--- a/app/index.native.tsx
+++ b/app/index.native.tsx
@@ -15,7 +15,7 @@ import { Logo } from "@/components/Logo";
 export default function NativeLanding() {
   const { uid }: UserState = useSelector((state: RootState) => state.user);
 
-  if (uid) return <Redirect href="/home" />;
+  if (uid) return <Redirect href="/me" />;
 
   return (
     <ThemedView style={{flex:1}} >

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -359,7 +359,7 @@ export default function App() {
         </ThemedView> });
   }, []);
 
-  if (uid) return <Redirect href="/home" />;
+  if (uid) return <Redirect href="/me" />;
   return (
     <ScrollView contentContainerStyle={{ backgroundColor: theme.colors.background }} style={{ flex: 1, backgroundColor: theme.colors.background }}>
       

--- a/app/me.tsx
+++ b/app/me.tsx
@@ -1,0 +1,39 @@
+import { ThemedView } from "@/components/ThemedView";
+import Mantra from "@/components/Mantra";
+import EmotionCheckCard from "@/components/EmotionCheckCard";
+import ToDoList from "@/components/ToDoList";
+import { Spacing } from "@/constants/spacing";
+import { BorderRadius } from "@/constants/borderRadius";
+import { RootState } from "@/redux/store";
+import { router } from "expo-router";
+import { ScrollView, View } from "react-native";
+import { FAB } from "react-native-paper";
+import { useSelector } from "react-redux";
+
+export default function MeScreen() {
+  const { uid } = useSelector((state: RootState) => state.user);
+
+  if (!uid) return null;
+  return (
+    <ThemedView style={{ flex: 1 }} type="default">
+      <ScrollView contentContainerStyle={{ paddingBottom: 120 }}>
+        <Mantra />
+        <EmotionCheckCard />
+        <View style={{ paddingHorizontal: Spacing.md, paddingTop: Spacing.md }}>
+          <ToDoList />
+        </View>
+      </ScrollView>
+      <FAB
+        icon="account"
+        label="Publikus Profilod"
+        onPress={() => router.push({ pathname: "/user/[uid]", params: { uid } })}
+        style={{
+          position: "absolute",
+          right: Spacing.md,
+          bottom: Spacing.md,
+          borderRadius: BorderRadius.pill,
+        }}
+      />
+    </ThemedView>
+  );
+}

--- a/components/EmotionCheckCard.tsx
+++ b/components/EmotionCheckCard.tsx
@@ -6,6 +6,7 @@ import { ThemedText } from "@/components/ThemedText";
 import { useEmotionLog } from "@/hooks/useEmotionLog";
 import EmotionPicker from "@/components/EmotionPicker";
 import { emotionAvailable } from "@/constants/emotionTiming";
+import { router } from "expo-router";
 
 type CardStatus = "idle" | "saving" | "saved" | "thanked" | "dismissed";
 
@@ -15,24 +16,12 @@ export default function EmotionCheckCard() {
 }
 
 function EmotionCheckCardInner() {
-  const { shouldShowCard, isYesterday, saveLog } = useEmotionLog();
+  const { shouldShowCard, saveLog } = useEmotionLog();
   const [selectedRate, setSelectedRate] = useState<number | null>(null);
   const [note, setNote] = useState("");
   const [status, setStatus] = useState<CardStatus>("idle");
 
-  if (!shouldShowCard || status === "dismissed") return null;
-
-  if (status === "thanked") {
-    return (
-      <Card style={{ margin: Spacing.xs }}>
-        <Card.Content>
-          <ThemedText type="bold" style={{ textAlign: "center", paddingVertical: Spacing.xs }}>
-            Köszi a válaszodat. {"\n"} Legyen szép napod! :)
-          </ThemedText>
-        </Card.Content>
-      </Card>
-    );
-  }
+  const showForm = shouldShowCard && status !== "dismissed" && status !== "thanked";
 
   const handleSave = async () => {
     if (selectedRate === null) return;
@@ -45,42 +34,57 @@ function EmotionCheckCardInner() {
   return (
     <Card style={{ margin: Spacing.xs }}>
       <Card.Title
-      titleStyle={{fontFamily:"Piazzolla-Medium"}}
-        title={isYesterday ? "Milyen napod volt tegnap?" : "Milyen napod volt?"}
+        titleStyle={{ fontFamily: "Piazzolla-Medium" }}
+        title="Hogy vagy?"
         right={() => (
-          <IconButton icon="close" onPress={() => setStatus("dismissed")} />
-        )}
-      />
-      <Card.Content>
-        <EmotionPicker
-          value={selectedRate}
-          onSelect={setSelectedRate}          
-          disabled={selectedRate === null || status === "saving" || status == "saved"}
-        />
-        {selectedRate !== null && (
-          <View style={{ marginTop: Spacing.sm }}>
-            <TextInput
-              label="Jegyzeteid"
-              placeholder="Írd le milyen napod volt, ha gondolod!"
-              value={note}
-              onChangeText={setNote}
-              multiline
-              numberOfLines={10}          
-              disabled={selectedRate === null || status === "saving" || status == "saved"}
-
+          <View style={{ flexDirection: "row" }}>
+            <IconButton
+              icon="calendar-month"
+              onPress={() => router.push("/user/emotion-history")}
             />
+            {showForm && (
+              <IconButton icon="close" onPress={() => setStatus("dismissed")} />
+            )}
           </View>
         )}
-        <Button
-          mode="contained"
-          onPress={handleSave}
-          disabled={selectedRate === null || status === "saving" || status == "saved"}
-          loading={status === "saving"}
-          style={{ marginTop: Spacing.md }}
-        >
-          {status === "saved" ? "Mentve!" : "Mentés"}
-        </Button>
-      </Card.Content>
+      />
+      {status === "thanked" ? (
+        <Card.Content>
+          <ThemedText type="bold" style={{ textAlign: "center", paddingVertical: Spacing.xs }}>
+            Köszi a válaszodat. {"\n"} Legyen szép napod! :)
+          </ThemedText>
+        </Card.Content>
+      ) : showForm ? (
+        <Card.Content>
+          <EmotionPicker
+            value={selectedRate}
+            onSelect={setSelectedRate}
+            disabled={selectedRate === null || status === "saving" || status == "saved"}
+          />
+          {selectedRate !== null && (
+            <View style={{ marginTop: Spacing.sm }}>
+              <TextInput
+                label="Jegyzeteid"
+                placeholder="Írd le milyen napod volt, ha gondolod!"
+                value={note}
+                onChangeText={setNote}
+                multiline
+                numberOfLines={10}
+                disabled={selectedRate === null || status === "saving" || status == "saved"}
+              />
+            </View>
+          )}
+          <Button
+            mode="contained"
+            onPress={handleSave}
+            disabled={selectedRate === null || status === "saving" || status == "saved"}
+            loading={status === "saving"}
+            style={{ marginTop: Spacing.md }}
+          >
+            {status === "saved" ? "Mentve!" : "Mentés"}
+          </Button>
+        </Card.Content>
+      ) : null}
     </Card>
   );
 }

--- a/components/Mantra.tsx
+++ b/components/Mantra.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { Platform, useWindowDimensions, View } from "react-native";
+import { IconButton, Text, TextInput } from "react-native-paper";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@/redux/store";
+import { setMantra } from "@/redux/reducers/userReducer";
+import { Spacing } from "@/constants/spacing";
+
+// react-native-web does not support adjustsFontSizeToFit
+const WEB_FONT_SIZE = 26;
+
+export default function Mantra() {
+  const dispatch = useDispatch();
+  const { mantra, name } = useSelector((state: RootState) => state.user);
+  const { width } = useWindowDimensions();
+
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+
+  const text = mantra || `Szia, ${name ?? ""}`;
+
+  const fontSize =
+    Platform.OS === "web"
+      ? WEB_FONT_SIZE
+      : Math.min(34, Math.max(16, Math.floor(((width - 120) / Math.max(text.length, 8)) * 1.8)));
+
+  const startEdit = () => {
+    setDraft(text);
+    setEditing(true);
+  };
+
+  const save = () => {
+    dispatch(setMantra(draft.trim()));
+    setEditing(false);
+  };
+
+  return (
+    <View
+      style={{
+        flexDirection: "row",
+        alignItems: "center",
+        paddingHorizontal: Spacing.lg,
+        paddingTop: Spacing.md,
+      }}
+    >
+      {editing ? (
+        <TextInput
+          value={draft}
+          onChangeText={setDraft}
+          onSubmitEditing={save}
+          dense
+          autoFocus
+          style={{ flex: 1, backgroundColor: "transparent" }}
+        />
+      ) : (
+        <Text
+          variant="headlineMedium"
+          numberOfLines={1}
+          adjustsFontSizeToFit={Platform.OS !== "web"}
+          style={{
+            flex: 1,
+            fontSize,
+            lineHeight: Math.ceil(fontSize * 1.3),
+            fontFamily: "Piazzolla-Medium",
+          }}
+        >
+          {text}
+        </Text>
+      )}
+      <IconButton
+        icon={editing ? "check" : "pencil"}
+        onPress={editing ? save : startEdit}
+      />
+    </View>
+  );
+}

--- a/components/MyAppBar.tsx
+++ b/components/MyAppBar.tsx
@@ -43,7 +43,7 @@ export const MyAppbar = ({ center, title, style }: { center?: ReactNode, title?:
       >
         <View style={{ width: 48 }} >
           {
-            navigation.canGoBack() && pathname !== "/home" && pathname !== "/" 
+            navigation.canGoBack() && pathname !== "/home" && pathname !== "/me" && pathname !== "/"
             && <Appbar.BackAction onPress={navigation.goBack} />
           }
         </View>

--- a/components/ToDoList.tsx
+++ b/components/ToDoList.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import { View } from "react-native";
+import { Icon, Surface, Text, TextInput, TouchableRipple } from "react-native-paper";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@/redux/store";
+import { addTask, toggleTask } from "@/redux/reducers/userReducer";
+import { Spacing } from "@/constants/spacing";
+import { BorderRadius } from "@/constants/borderRadius";
+import { useAppTheme } from "@/assets/theme";
+import { ThemedText } from "./ThemedText";
+
+export default function ToDoList() {
+  const theme = useAppTheme();
+  const dispatch = useDispatch();
+  const tasks = useSelector((state: RootState) => state.user.tasks) ?? [];
+  // Tasks already checked at mount stay hidden; ones checked during this
+  // session stay in place.
+  const [hiddenIds] = useState(() =>
+    tasks.filter((task) => task.checked).map((task) => task.id),
+  );
+  const [newTitle, setNewTitle] = useState("");
+
+  const visibleTasks = tasks.filter((task) => !hiddenIds.includes(task.id));
+
+  const handleAdd = () => {
+    const title = newTitle.trim();
+    if (!title) return;
+    dispatch(
+      addTask({
+        id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+        title,
+        checked: false,
+      }),
+    );
+    setNewTitle("");
+  };
+
+  return (
+    <View style={{ gap: Spacing.sm }}>
+      <View style={{ flexDirection: "row", alignItems: "flex-end", gap: Spacing.xs }}>
+        <ThemedText variant="labelLarge" type="bold" style={{ color: theme.colors.secondary }}>
+          Feladatok
+        </ThemedText>
+      </View>
+      <Surface
+        style={{
+          flexDirection: "column",
+          borderRadius: BorderRadius.lg,
+          paddingVertical: Spacing.md,
+          paddingHorizontal: Spacing.lg,
+          width: "100%",
+        }}
+        elevation={1}
+      >
+        {visibleTasks.map((task) => (
+          <TouchableRipple
+            key={task.id}
+            onPress={() => dispatch(toggleTask(task.id))}
+            style={{ borderRadius: BorderRadius.sm }}
+          >
+            <View
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                paddingVertical: Spacing.sm,
+                gap: Spacing.md,
+              }}
+            >
+              <Text
+                variant="bodyLarge"
+                style={{
+                  flex: 1,
+                  textDecorationLine: task.checked ? "line-through" : "none",
+                  color: task.checked ? theme.colors.onSurfaceVariant : theme.colors.onSurface,
+                }}
+              >
+                {task.title}
+              </Text>
+              <View style={{ alignSelf: "flex-end" }}>
+                <Icon
+                  source={task.checked ? "check-circle" : "checkbox-blank-circle-outline"}
+                  size={24}
+                  color={task.checked ? theme.colors.primary : theme.colors.onSurfaceVariant}
+                />
+              </View>
+            </View>
+          </TouchableRipple>
+        ))}
+        <TextInput
+          mode="flat"
+          dense
+          label="Új feladat"
+          value={newTitle}
+          onChangeText={setNewTitle}
+          onSubmitEditing={handleAdd}
+          style={{
+            backgroundColor: "transparent",
+            marginTop: visibleTasks.length ? Spacing.xs : 0,
+          }}
+          right={
+            <TextInput.Icon icon="plus" onPress={handleAdd} disabled={!newTitle.trim()} />
+          }
+        />
+      </Surface>
+    </View>
+  );
+}

--- a/components/navigation/BottomNavigation.tsx
+++ b/components/navigation/BottomNavigation.tsx
@@ -15,11 +15,11 @@ const BottomNavigation = () => {
   const { functions } = useSelector((state: RootState) => state.tutorial);
 
   const bizniszActive = segment[0]?.includes("biznisz");
-  const profilActive = segment[0]?.includes("user");
-  const homeActive = segment[0]?.includes("home");
+  const meActive = segment[0] === "me" || segment[0]?.includes("user");
+  const homeActive = segment[0]?.includes("home") || segment[0]?.includes("fifeRadar");
   const lastNavTime = useRef(0);
 
-  const navigateTo = useCallback((path: "/biznisz" | "/home" | "/user") => {
+  const navigateTo = useCallback((path: "/biznisz" | "/home" | "/me") => {
     const now = Date.now();
     if (now - lastNavTime.current < 300) return;
     lastNavTime.current = now;
@@ -49,26 +49,26 @@ const BottomNavigation = () => {
         <TouchableRipple style={{ ...styles.button }} onPress={() => navigateTo("/home")}>
           <View style={{ alignItems: "center" }}>
             <Icon
-              source={homeActive ? "home" : "home-outline"}
+              source={homeActive ? "account-group" : "account-group-outline"}
               size={homeActive ? 30 : 24}
               color={homeActive ? theme.colors.secondary : undefined}
             />
             <ThemedText type={homeActive ? "defaultSemiBold" : "default"}>
-              Otthon
+              Ti
             </ThemedText>
           </View>
         </TouchableRipple>
       </Measure>
       <Measure name="user">
-        <TouchableRipple style={{ ...styles.button }} onPress={() => navigateTo("/user")}>
+        <TouchableRipple style={{ ...styles.button }} onPress={() => navigateTo("/me")}>
           <View style={{ alignItems: "center" }}>
             <Icon
-              source={profilActive ? "account" : "account-outline"}
-              size={profilActive ? 30 : 24}
-              color={profilActive ? theme.colors.secondary : undefined}
+              source={meActive ? "account" : "account-outline"}
+              size={meActive ? 30 : 24}
+              color={meActive ? theme.colors.secondary : undefined}
             />
-            <ThemedText type={profilActive ? "defaultSemiBold" : "default"}>
-              Profil
+            <ThemedText type={meActive ? "defaultSemiBold" : "default"}>
+              Én
             </ThemedText>
           </View>
         </TouchableRipple>

--- a/components/tutorial/TutorialOverlay.tsx
+++ b/components/tutorial/TutorialOverlay.tsx
@@ -30,17 +30,17 @@ const tutorialSteps: { message?: string; description?: string; key?: string; pag
   {
     message: "Üdvözöllek a FiFe Appban!",
     description: "Ez egy bemutató a funkciókról, átugorhatod ha akarod.",
-    page: "/home"
+    page: "/me"
   },
   {
     key: "first-user",
     message: "Ez a főoldal, itt láthatod az újonan regisztrált tagokat, és hogy mihez értenek",
-    page: "/home"
+    page: "/me"
   },
   {
     key: "biznisz",
     message: "A bizniszeket itt, alul találod.",
-    page: "/home"
+    page: "/me"
   },
   {
     message: "Ez a biznisz kereső oldal",

--- a/components/user/FiFeRadar.tsx
+++ b/components/user/FiFeRadar.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { FlatList, Pressable, View } from "react-native";
+import { ActivityIndicator, Icon, IconButton, Text } from "react-native-paper";
+import { Link, router } from "expo-router";
+import { NearestProfile } from "@/redux/store.type";
+import ProfileImage from "../ProfileImage";
+import { ThemedText } from "../ThemedText";
+import { ThemedView } from "../ThemedView";
+import { Spacing } from "@/constants/spacing";
+import { BorderRadius } from "@/constants/borderRadius";
+import { theme } from "@/assets/theme";
+
+interface FiFeRadarProps {
+  data: NearestProfile[];
+  load?: () => void;
+  canLoadMore?: boolean;
+  loading?: boolean;
+  error?: string | null;
+}
+
+/** Alternating layout: even items show image with name below,
+ * odd items show name on top with image below. */
+const RadarItem = ({ data, reversed }: { data: NearestProfile; reversed: boolean }) => (
+  <Link href={{ pathname: "/user/[uid]", params: { uid: data.id } }} asChild>
+    <Pressable>
+      <View
+        style={{
+          width: 92,
+          alignItems: "center",
+          gap: Spacing.xs,
+          flexDirection: reversed ? "column-reverse" : "column",
+        }}
+      >
+        <ProfileImage
+          uid={data.id}
+          avatar_url={data.avatar_url}
+          style={{ width: 72, height: 72, borderRadius: BorderRadius.full }}
+        />
+        <Text variant="labelMedium" numberOfLines={1} style={{ textAlign: "center", maxWidth: 88 }}>
+          {data.full_name || "Nincs név"}
+        </Text>
+      </View>
+    </Pressable>
+  </Link>
+);
+
+export const FiFeRadar: React.FC<FiFeRadarProps> = ({
+  data,
+  load,
+  canLoadMore,
+  loading,
+  error,
+}) => {
+  const users = data.filter((item) => item.id !== "-1");
+
+  return (
+    <View>
+      <ThemedView
+        type="card"
+        style={{
+          paddingHorizontal: Spacing.lg,
+          paddingVertical: Spacing.sm,
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <View style={{ flexDirection: "row", alignItems: "flex-end", gap: Spacing.xs }}>
+          <ThemedText variant="labelLarge" type="bold" style={{ color: theme.colors.secondary }}>
+            FiFe Radar
+          </ThemedText>
+          <Icon size={18} color={theme.colors.secondary} source="wifi" />
+        </View>
+        <IconButton
+          icon="chevron-right"
+          size={22}
+          style={{ margin: 0 }}
+          onPress={() => router.push("/fifeRadar")}
+        />
+      </ThemedView>
+      {!!error && (
+        <ThemedView style={{ margin: 6, alignItems: "center" }} type="error">
+          <ThemedText type="error">{error}</ThemedText>
+        </ThemedView>
+      )}
+      <FlatList
+        horizontal
+        data={users}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item, index }) => (
+          <RadarItem data={item} reversed={index % 2 === 1} />
+        )}
+        contentContainerStyle={{
+          gap: Spacing.md,
+          paddingHorizontal: Spacing.md,
+          paddingVertical: Spacing.sm,
+          alignItems: "center",
+        }}
+        showsHorizontalScrollIndicator={false}
+        onEndReached={() => {
+          if (canLoadMore && !loading) load?.();
+        }}
+        onEndReachedThreshold={0.7}
+        ListFooterComponent={
+          canLoadMore && !!users.length ? (
+            <ActivityIndicator style={{ marginHorizontal: Spacing.md }} />
+          ) : null
+        }
+        ListEmptyComponent={
+          loading ? <ActivityIndicator style={{ padding: Spacing.lg }} /> : null
+        }
+      />
+    </View>
+  );
+};

--- a/hooks/useNearbyBuzinesses.ts
+++ b/hooks/useNearbyBuzinesses.ts
@@ -1,0 +1,71 @@
+import { useCallback, useState } from "react";
+import { useSelector } from "react-redux";
+import { supabase } from "@/lib/supabase/supabase";
+import { RootState } from "@/redux/store";
+import { BuzinessSearchItemInterface } from "@/redux/store.type";
+import { useMyLocation } from "./useMyLocation";
+
+/** Nearest buzinesses via hybrid_buziness_search (business-search edge function)
+ * without text search. Uses local state so the biznisz page's redux-backed
+ * results stay untouched. */
+export function useNearbyBuzinesses(take = 5) {
+  const { myLocation } = useMyLocation();
+
+  // Profile location as fallback when GPS is not available
+  const profileLocation = useSelector(
+    (state: RootState) => state.user.userData?.location,
+  );
+
+  const [data, setData] = useState<BuzinessSearchItemInterface[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    const searchLocation = myLocation
+      ? {
+        lat: myLocation.coords.latitude,
+        long: myLocation.coords.longitude,
+      }
+      : profileLocation
+        ? {
+          lat: profileLocation.lat,
+          long: profileLocation.lng,
+        }
+        : {
+          lat: 47.4979,
+          long: 19.0402,
+        };
+
+    try {
+      const { data: buzinesses, error } = await supabase.functions.invoke(
+        "business-search",
+        {
+          body: {
+            query: "",
+            take,
+            skip: 0,
+            ingyen: false,
+            maxdistance: 100000,
+            ...searchLocation,
+          },
+        },
+      );
+
+      if (error) {
+        setError(error.message);
+        setData([]);
+      } else {
+        setData(buzinesses || []);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setData([]);
+    }
+    setLoading(false);
+  }, [myLocation, profileLocation, take]);
+
+  return { data, loading, error, fetch };
+}

--- a/lib/notifications/scheduleDailyEmotionReminder.ts
+++ b/lib/notifications/scheduleDailyEmotionReminder.ts
@@ -7,9 +7,9 @@ export async function scheduleDailyEmotionReminder() {
   await Notifications.scheduleNotificationAsync({
     identifier: ID,
     content: {
-      title: "Milyen napod volt ma?",
-      body: "Értékeld a napodat!",
-      data: { url: "/home" },
+      title: "Hogy vagy?",
+      body: "Mesélj a napodról, ha van egy perced!",
+      data: { url: "/me" },
     },
     trigger: {
       type: Notifications.SchedulableTriggerInputTypes.DAILY,

--- a/redux/reducers/userReducer.ts
+++ b/redux/reducers/userReducer.ts
@@ -1,5 +1,5 @@
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
-import { UserState } from "../store.type";
+import { TaskItem, UserState } from "../store.type";
 import { DEFAULT_THEME_PREFERENCE } from "@/assets/theme";
 
 const initialState: UserState = {
@@ -35,6 +35,17 @@ const userReducer = createSlice({
     },
     setName: (state, { payload }) => {
       state.name = payload;
+    },
+    setMantra: (state, { payload }: PayloadAction<string>) => {
+      state.mantra = payload;
+    },
+    addTask: (state, { payload }: PayloadAction<TaskItem>) => {
+      state.tasks = [...(state.tasks ?? []), payload];
+    },
+    toggleTask: (state, { payload }: PayloadAction<string>) => {
+      state.tasks = (state.tasks ?? []).map((task) =>
+        task.id === payload ? { ...task, checked: !task.checked } : task,
+      );
     },
     setLocationError: (state, { payload }: PayloadAction<string | null>) => {
       state.locationError = payload;
@@ -83,6 +94,9 @@ export const {
   login,
   logout,
   setName,
+  setMantra,
+  addTask,
+  toggleTask,
   setUserData,
   setLocationError,
   setThemePreference,

--- a/redux/store.type.ts
+++ b/redux/store.type.ts
@@ -15,9 +15,17 @@ export interface EmotionLogsState {
   logs: EmotionLogLocal[];
 }
 
+export interface TaskItem {
+  id: string;
+  title: string;
+  checked: boolean;
+}
+
 export interface UserState {
   uid?: string;
   name?: string;
+  mantra?: string;
+  tasks?: TaskItem[];
   locationAlertDismissed?: boolean;
   notificationPrefs?: {
     notifyPush: boolean;


### PR DESCRIPTION
## Summary
This PR restructures the home screen to improve modularity and user experience by extracting the FiFe Radar functionality into a dedicated page, creating a new personal dashboard screen, and adding a nearby businesses feature.

## Key Changes

- **Extracted FiFe Radar to dedicated page** (`/fifeRadar`): Moved the full user search interface with map selector from the home screen to a new dedicated route, reducing home screen complexity
- **Created new personal dashboard** (`/me`): New screen featuring:
  - Editable mantra/greeting message
  - Emotion check-in card
  - Task/to-do list management with add/toggle functionality
- **Added nearby businesses feature**: 
  - New `useNearbyBuzinesses` hook that fetches businesses via the business-search edge function
  - `BuzinessItem` component for displaying business listings
  - Displays nearby businesses on the home screen based on GPS or profile location
- **Refactored home screen**: Now displays a horizontal scrolling FiFe Radar preview (via new `FiFeRadar` component) and nearby businesses list, serving as a dashboard
- **Updated navigation**:
  - Bottom navigation now routes to `/me` instead of `/user` for the profile tab
  - Home tab now covers both `/home` and `/fifeRadar` routes
  - Updated tutorial overlay to start on `/me` page
- **Enhanced user state management**: Added `mantra` and `tasks` fields to Redux user state with corresponding actions (`setMantra`, `addTask`, `toggleTask`)
- **Improved emotion check-in**: Added history navigation button and simplified card title

## Notable Implementation Details

- The `FiFeRadar` component uses alternating layout (reversed flex direction) for visual variety in the horizontal list
- `useNearbyBuzinesses` falls back to profile location when GPS is unavailable, with Budapest coordinates as final fallback
- Task IDs are generated using timestamp and random string for uniqueness
- Mantra text dynamically adjusts font size based on content length and screen width

https://claude.ai/code/session_012gtfNu2o1qXuZEaFgM7n3s