### PR TITLE
Replace custom buffer package with native Node.js buffer

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -81,13 +81,15 @@ export default {
         "android": {
           "compileSdkVersion": 36,
           "targetSdkVersion": 36,
-          "minSdkVersion": 24
+          "minSdkVersion": 24,
+          "enableMinifyInReleaseBuilds": true,
+          "enableShrinkResourcesInReleaseBuilds": true
         },
         "ios": {
           "useFrameworks": "static"
         }
       }
-    ], 
+    ],
     [
         "expo-splash-screen",
         {

--- a/lib/functions/locationToCoords.ts
+++ b/lib/functions/locationToCoords.ts
@@ -1,5 +1,5 @@
 const locationToCoords = (geometry: string): number[] => {
-  const Buffer = require("@craftzdog/react-native-buffer").Buffer;
+  const Buffer = require("buffer").Buffer;
   const wkx = require("wkx");
 
   const wkbBuffer = new Buffer(geometry, "hex");

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@craftzdog/react-native-buffer": "^6.0.5",
         "@expo/match-media": "^0.4.0",
         "@expo/metro-runtime": "~55.0.9",
         "@expo/vector-icons": "^15.0.3",
@@ -2270,30 +2269,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@craftzdog/react-native-buffer": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@craftzdog/react-native-buffer/-/react-native-buffer-6.0.5.tgz",
-      "integrity": "sha512-Av+YqfwA9e7jhgI9GFE/gTpwl/H+dRRLmZyJPOpKTy107j9Oj7oXlm3/YiMNz+C/CEGqcKAOqnXDLs4OL6AAFw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "ieee754": "^1.2.1",
-        "react-native-quick-base64": "^2.0.5"
       }
     },
     "node_modules/@egjs/hammerjs": {
@@ -33198,19 +33173,6 @@
         "react-native-url-polyfill": "*",
         "text-encoding": "*",
         "web-streams-polyfill": "*"
-      }
-    },
-    "node_modules/react-native-quick-base64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/react-native-quick-base64/-/react-native-quick-base64-2.1.2.tgz",
-      "integrity": "sha512-xghaXpWdB0ji8OwYyo0fWezRroNxiNFCNFpGUIyE7+qc4gA/IGWnysIG5L0MbdoORv8FkTKUvfd6yCUN5R2VFA==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/react-native-reanimated": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     ]
   },
   "dependencies": {
-    "@craftzdog/react-native-buffer": "^6.0.5",
     "@expo/match-media": "^0.4.0",
     "@expo/metro-runtime": "~55.0.9",
     "@expo/vector-icons": "^15.0.3",


### PR DESCRIPTION
## Summary
This PR removes the dependency on `@craftzdog/react-native-buffer` and replaces it with the native Node.js `buffer` package, while also enabling minification and resource shrinking for Android release builds.

## Key Changes
- **Buffer import**: Updated `locationToCoords.ts` to import `Buffer` from the standard `buffer` package instead of `@craftzdog/react-native-buffer`
- **Dependency removal**: Removed `@craftzdog/react-native-buffer` from package.json dependencies
- **Android optimization**: Enabled `enableMinifyInReleaseBuilds` and `enableShrinkResourcesInReleaseBuilds` in the Android build configuration to reduce APK size
- **Code formatting**: Fixed trailing whitespace in app.config.js

## Implementation Details
The `Buffer` API remains compatible between the two packages, so the functionality of `locationToCoords` is preserved while reducing external dependencies. The Android build optimizations will help reduce the final APK size for release builds.

https://claude.ai/code/session_01AUKHzqHYheM885WgMXR9Bq