### PR TITLE
Fix wkx patch to use buffer instead of removed @craftzdog/react-nativ…

### DIFF
--- a/patches/wkx+0.5.0.patch
+++ b/patches/wkx+0.5.0.patch
@@ -9,23 +9,23 @@ index 1675337..265cf07 100644
  function BinaryReader(buffer, isBigEndian) {
      this.buffer = buffer;
 diff --git a/node_modules/wkx/lib/binarywriter.js b/node_modules/wkx/lib/binarywriter.js
-index 99dc454..eb06d4e 100644
+index 99dc454..2503651 100644
 --- a/node_modules/wkx/lib/binarywriter.js
 +++ b/node_modules/wkx/lib/binarywriter.js
 @@ -1,4 +1,6 @@
  module.exports = BinaryWriter;
-+import { Buffer } from "@craftzdog/react-native-buffer";
++var Buffer = require("buffer").Buffer;
 +
  
  function BinaryWriter(size, allowResize) {
      this.buffer = new Buffer(size);
 diff --git a/node_modules/wkx/lib/geometry.js b/node_modules/wkx/lib/geometry.js
-index 37d1bef..a32be9f 100644
+index 37d1bef..ece654b 100644
 --- a/node_modules/wkx/lib/geometry.js
 +++ b/node_modules/wkx/lib/geometry.js
 @@ -1,4 +1,6 @@
  module.exports = Geometry;
-+import { Buffer } from "@craftzdog/react-native-buffer";
++var Buffer = require("buffer").Buffer;
 +
  
  var Types = require('./types');


### PR DESCRIPTION
…e-buffer

Commit 9fc520b dropped @craftzdog/react-native-buffer from package.json but missed that patches/wkx+0.5.0.patch still injected an import of it into wkx/lib/geometry.js and wkx/lib/binarywriter.js, breaking Metro web bundling (and thus `expo export -p web` / the netlify deploy script) with "Unable to resolve module @craftzdog/react-native-buffer". Point both patched files at the already-installed `buffer` package instead, matching binaryreader.js.